### PR TITLE
Rename toggleDnssec to setDnssec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v0.2.3 - Unreleased](https://github.com/exonet/powerdns-php/compare/v0.2.3...develop)
+[Compare v0.2.4 - Unreleased](https://github.com/exonet/powerdns-php/compare/v0.2.4...develop)
+
+## [v0.2.4](https://github.com/exonet/powerdns-php/releases/tag/v0.2.4) - 2019-06-18
+[Compare v0.2.3 - v0.2.3](https://github.com/exonet/powerdns-php/compare/v0.2.3...v0.2.4)
+### Changed
+- Renamed the `toggleDnssec` method to `setDnssec`.
 
 ## [v0.2.3](https://github.com/exonet/powerdns-php/releases/tag/v0.2.3) - 2019-04-10
 [Compare v0.2.2 - v0.2.3](https://github.com/exonet/powerdns-php/compare/v0.2.2...v0.2.3)

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -12,7 +12,7 @@ class Powerdns
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v0.2.0';
+    public const CLIENT_VERSION = 'v0.2.4';
 
     /**
      * @var Powerdns The client instance.

--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -55,6 +55,9 @@ class ResourceRecord
      */
     private $zone;
 
+    /**
+     * @var bool If true then this record is based on an existing record from an API response.
+     */
     private $existingRecord = false;
 
     /**

--- a/src/Transformers/DnssecTransformer.php
+++ b/src/Transformers/DnssecTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Exonet\Powerdns\Transformers;
 
-class DnssecToggleTransformer extends Transformer
+class DnssecTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -5,7 +5,7 @@ namespace Exonet\Powerdns;
 use Exonet\Powerdns\Resources\Record;
 use Exonet\Powerdns\Resources\ResourceRecord;
 use Exonet\Powerdns\Resources\ResourceSet;
-use Exonet\Powerdns\Transformers\DnssecToggleTransformer;
+use Exonet\Powerdns\Transformers\DnssecTransformer;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
 
 class Zone extends AbstractZone
@@ -154,7 +154,7 @@ class Zone extends AbstractZone
      */
     public function enableDnssec() : bool
     {
-        return $this->toggleDnssec(true);
+        return $this->setDnssec(true);
     }
 
     /**
@@ -164,7 +164,7 @@ class Zone extends AbstractZone
      */
     public function disableDnssec() : bool
     {
-        return $this->toggleDnssec(false);
+        return $this->setDnssec(false);
     }
 
     /**
@@ -174,9 +174,9 @@ class Zone extends AbstractZone
      *
      * @return bool True when the request succeeded.
      */
-    public function toggleDnssec(bool $state) : bool
+    public function setDnssec(bool $state) : bool
     {
-        $result = $this->connector->put($this->getZonePath(), new DnssecToggleTransformer(['dnssec' => $state]));
+        $result = $this->connector->put($this->getZonePath(), new DnssecTransformer(['dnssec' => $state]));
 
         /*
          * The PUT request will return an 204 No Content, so the $result is empty. If this is the case, the PATCH was


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Rename `toggleDnssec` to `setDnssec`
- Added a missing docblock
- Updated the `CLIENT_VERSION`

## Motivation and context
A toggle indicates that the value is flipped, however the implementation of the method is just a setter. This is why the method name was changed.