### PR TITLE
Fix Travis build status icon and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 [ico-version]: https://img.shields.io/packagist/v/exonet/powerdns-php.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/exonet/powerdns-php/master.svg?style=flat-square
+[ico-travis]: https://img.shields.io/travis/com/exonet/powerdns-php/master.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/exonet/powerdns-php.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/exonet/powerdns-php
-[link-travis]: https://travis-ci.org/exonet/powerdns-php
+[link-travis]: https://travis-ci.com/exonet/powerdns-php
 [link-downloads]: https://packagist.org/packages/exonet/powerdns-php
 [link-author]: https://github.com/exonet
 [link-contributors]: ../../contributors


### PR DESCRIPTION
Fix Travis build status icon and link to point to the `.com` version of Travis, instead of the `.org`.