### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v1.0.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v1.0.0...develop)
+[Compare v1.0.1 - Unreleased](https://github.com/exonet/powerdns-php/compare/v1.0.1...develop)
+
+## [v1.0.1](https://github.com/exonet/powerdns-php/releases/tag/v1.0.1) - 2019-07-17
+[Compare v1.0.0 - v1.0.1](https://github.com/exonet/powerdns-php/compare/v1.0.0...v1.0.1)
+### Changed
+- The `Content-Type` header is now also set when making calls to the API. ([#11](https://github.com/exonet/powerdns-php/issues/11))
+
+### Fixed
+- Changed the payload key from `set_ptr` to the correct `set-ptr` in the RRSetTransformer. ([#12](https://github.com/exonet/powerdns-php/issues/12))
 
 ## [v1.0.0](https://github.com/exonet/powerdns-php/releases/tag/v1.0.0) - 2019-07-05
 [Compare v0.2.4 - v1.0.0](https://github.com/exonet/powerdns-php/compare/v0.2.4...v1.0.0)

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -156,7 +156,9 @@ class Connector
                 break;
         }
 
-        throw new PowerdnsException($contents['error']);
+        $error = isset($contents['error']) ? $contents['error'] : $contents;
+
+        throw new PowerdnsException($error);
     }
 
     /**

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -191,6 +191,7 @@ class Connector
         return [
             'X-API-Key' => $this->powerdns->getConfig()['apiKey'],
             'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
             'User-Agent' => 'exonet-powerdns-php/'.Powerdns::CLIENT_VERSION,
         ];
     }

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -12,7 +12,7 @@ class Powerdns
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v1.0.0';
+    public const CLIENT_VERSION = 'v1.0.1';
 
     /**
      * @var Powerdns The client instance.

--- a/src/Transformers/RRSetTransformer.php
+++ b/src/Transformers/RRSetTransformer.php
@@ -55,7 +55,7 @@ class RRSetTransformer extends Transformer
     {
         return (object) [
             'content' => $record->getContent(),
-            'set_ptr' => $record->isSetPtr(),
+            'set-ptr' => $record->isSetPtr(),
             'disabled' => $record->isDisabled(),
         ];
     }


### PR DESCRIPTION
## Description
Release version 1.0.1 of this package.

fixes #11 
fixes #12 

```
[Compare v1.0.0 - v1.0.1](https://github.com/exonet/powerdns-php/compare/v1.0.0...v1.0.1)
### Changed
- The `Content-Type` header is now also set when making calls to the API. ([#11](https://github.com/exonet/powerdns-php/issues/11))

### Fixed
- Changed the payload key from `set_ptr` to the correct `set-ptr` in the RRSetTransformer. ([#12](https://github.com/exonet/powerdns-php/issues/12))
```