### PR TITLE
Enhancement: Add support to list zones

### DIFF
--- a/src/AbstractZone.php
+++ b/src/AbstractZone.php
@@ -85,4 +85,14 @@ abstract class AbstractZone
     {
         return sprintf('zones/%s%s', $this->zone, $path);
     }
+
+    /**
+     * Get the canonical name of the zone. Includes the trailing dot (.).
+     *
+     * @return string
+     */
+    public function getCanonicalName(): string
+    {
+        return $this->zone;
+    }
 }

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -175,6 +175,21 @@ class Powerdns
     }
 
     /**
+     * Retrieve all zones.
+     *
+     * @return Zone[] Array containing the zones
+     */
+    public function listZones() : array
+    {
+        return array_map(
+            function (array $args) {
+                return new Zone($this->connector, $args['id']);
+            },
+            $this->connector->get('zones')
+        );
+    }
+
+    /**
      * Get a cryptokey instance to work with.
      *
      * @param string $canonicalDomain The canonical domain name of the zone.

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -55,4 +55,46 @@ class PowerdnsTest extends TestCase
         $this->assertInstanceOf(Zone::class, $zone);
         $this->assertTrue($powerDns->deleteZone('test.nl.'));
     }
+
+    public function testListZones() : void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('get')->withArgs(['zones'])->once()->andReturn(
+            [
+                [
+                    'account' => '',
+                    'dnssec' => false,
+                    'id' => 'example.co.uk',
+                    'kind' => 'Native',
+                    'last_check' => 0,
+                    'masters' => [],
+                    'name' => 'example.',
+                    'notified_serial' => 0,
+                    'serial' => 2019100101,
+                    'url' => '/api/v1/servers/localhost/zones/example.co.uk',
+                ],
+                [
+                    'account' => '',
+                    'dnssec' => false,
+                    'id' => 'example.com',
+                    'kind' => 'Native',
+                    'last_check' => 0,
+                    'masters' => [],
+                    'name' => 'example.',
+                    'notified_serial' => 0,
+                    'serial' => 2019100102,
+                    'url' => '/api/v1/servers/localhost/zones/example.com',
+                ],
+            ]
+        );
+
+        $powerDns = new Powerdns(null, null, null, null, $connector);
+
+        $response = $powerDns->listZones();
+        $this->assertIsArray($response);
+        $this->assertCount(2, $response);
+        foreach ($response as $zone) {
+            $this->assertInstanceOf(Zone::class, $zone);
+        }
+    }
 }

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -112,4 +112,11 @@ class ZoneTest extends TestCase
         $this->assertSame(1, $zone->find('record01.test.nl.')->count());
         $this->assertSame(0, $zone->find('record01.test.nl.', 'MX')->count());
     }
+
+    public function testGetCanonicalName(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $zone = new Zone($connector, 'test.nl');
+        $this->assertSame('test.nl'.'.', $zone->getCanonicalName());
+    }
 }


### PR DESCRIPTION
Feature enhancement: list domains to support bulk operations.
new method:
```
$powerdns->listZones: Zone[];
```

Once working with Zone[], knowing what zone is being returned is helpful for consuming code.
```
$zone->getCanonicalName(): string;
```
