### PR TITLE
(GH-25) Allow nsec3param entries to be added

### DIFF
--- a/src/Transformers/Nsec3paramTransformer.php
+++ b/src/Transformers/Nsec3paramTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class Nsec3paramTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        return (object) [
+            'nsec3param' => $this->data->getNsec3param(),
+        ];
+    }
+}


### PR DESCRIPTION
Changes to the `Zone` class to allow nsec3param entries to be set.

## Description

I added a `put` function inside the `Zone` class. This is the generic put method for a Zone object.
I added a `setNsec3param` function inside the `Zone` class to set NSEC3PARMS
I modified the `setDnssec` function to use the new put method

## Motivation and context

fixes #25 

## How has this been tested?

This has been tested on our sandbox environment

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [ ] I'm creating this PR to the `develop` branch. **(there is no develop branch?)**
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. **(PUT request seem not be supported by Mockery)**
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
