### PR TITLE
Improve NSEC3PARAM validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## Unreleased
 [Compare v2.1.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.1.0...develop)
 ## [v2.1.0](https://github.com/exonet/powerdns-php/releases/tag/v2.1.0) - 2020-03-11
-[Compare v2.0.0 - v2.1.0](https://github.com/exonet/powerdns-php/compare/v2.2.0...v2.1.0)
+[Compare v2.0.0 - v2.1.0](https://github.com/exonet/powerdns-php/compare/v2.0.0...v2.1.0)
 ### Added
 - It is now possible to set the NSEC3PARAM on a zone. ([mkevenaar-docktera](https://github.com/mkevenaar-docktera) - #25 #26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.0.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.0.0...develop)
+[Compare v2.1.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.1.0...develop)
+## [v2.1.0](https://github.com/exonet/powerdns-php/releases/tag/v2.1.0) - 2020-03-11
+[Compare v2.0.0 - v2.1.0](https://github.com/exonet/powerdns-php/compare/v2.2.0...v2.1.0)
+### Added
+- It is now possible to set the NSEC3PARAM on a zone. ([mkevenaar-docktera](https://github.com/mkevenaar-docktera) - #25 #26)
+
+### Changed
+- The validation of the NSEC3PARAM is improved. (#27)
 
 ## [v2.0.0](https://github.com/exonet/powerdns-php/releases/tag/v2.0.0) - 2020-01-29
 [Compare v1.1.0 - v2.0.0](https://github.com/exonet/powerdns-php/compare/v1.1.0...v2.0.0)

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -344,19 +344,19 @@ class Zone
      */
     public function setNsec3param(string $nsec3param): self
     {
-        // Validate the nsec3param.
-        [$algorithm, $flags, $iterations, $salt] = explode(' ', $nsec3param);
+        // Validate the nsec3param. Set null if the given string has not enough arguments.
+        [$algorithm, $flags, $iterations, $salt] = explode(' ', $nsec3param) + [null, null, null, null];
 
-        if ((int) $algorithm !== 1) {
+        if ($algorithm === null || !ctype_digit($algorithm) || (int) $algorithm !== 1) {
             throw new InvalidNsec3Param('The nsec3param hash algorithm parameter must be set to 1.');
         }
-        if ((int) $flags !== 0) {
-            throw new InvalidNsec3Param('The nsec3param flags parameter must be set to 0.');
+        if ($flags === null || !ctype_digit($flags) || ((int) $flags !== 0 && (int) $flags !== 1)) {
+            throw new InvalidNsec3Param('The nsec3param flags parameter must be set to 0 or 1.');
         }
-        if ($iterations === 0 || $iterations > 2500) {
+        if ($iterations === null || !ctype_digit($iterations) || $iterations === 0 || $iterations > 2500) {
             throw new InvalidNsec3Param('The nsec3param iterations parameter must be between 0 and 2500.');
         }
-        if (strlen($salt) === 0 || strlen($salt) > 255) {
+        if ($salt === null || strlen($salt) === 0 || strlen($salt) > 255) {
             throw new InvalidNsec3Param('The nsec3param hash salt length must be between 0 and 255 characters.');
         }
 

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -308,7 +308,7 @@ class Zone
     public function setMasters(array $masters): self
     {
         if ($this->kind !== 'Slave') {
-            throw new InvalidKindType(sprintf('Only "Slave" kind zones can set masters, not "%".', $this->kind));
+            throw new InvalidKindType(sprintf('Only "Slave" kind zones can set masters, not "%s".', $this->kind));
         }
 
         $this->masters = $masters;

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -94,7 +94,7 @@ class ZoneTest extends TestCase
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
-        $zone->setNsec3param('1 1 100 f00bar');
+        $zone->setNsec3param('1 2 100 f00bar');
     }
 
     public function test_setNsec3param_InvalidIteration_ExceptionThrown()
@@ -111,7 +111,21 @@ class ZoneTest extends TestCase
         $zone->setNsec3param('1 0 100 '.str_repeat('a', 256));
     }
 
-    public function test_setNsec3param_ProperParM_GetParam()
+    public function test_setNsec3param_TooFewArguments_ExceptionThrown()
+    {
+        $this->expectException(InvalidNsec3Param::class);
+        $zone = new Zone();
+        $zone->setNsec3param('1 0');
+    }
+
+    public function test_setNsec3param_InvalidArgument_ExceptionThrown()
+    {
+        $this->expectException(InvalidNsec3Param::class);
+        $zone = new Zone();
+        $zone->setNsec3param('unit-test');
+    }
+
+    public function test_setNsec3param()
     {
         $zone = new Zone();
         $zone->setNsec3param('1 0 100 f00Bar');

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class ZoneTest extends TestCase
 {
-    public function test_SetApiResponse_WithFullData_GetData()
+    public function testSetApiResponse(): void
     {
         $zone = new Zone();
 
@@ -40,7 +40,7 @@ class ZoneTest extends TestCase
         $this->assertSame([], $zone->getNameservers());
     }
 
-    public function test_SetApiResponse_WithOptionalData_GetData()
+    public function testSetApiResponseWithoutOptionalData(): void
     {
         $zone = new Zone();
 
@@ -62,73 +62,92 @@ class ZoneTest extends TestCase
         $this->assertNull($zone->getAccount());
     }
 
-    public function test_SetNameservers_NameserverSet()
+    public function testSetNameservers(): void
     {
         $zone = new Zone();
         $zone->setNameservers(['foo', 'bar']);
         $this->assertSame(['foo', 'bar'], $zone->getNameservers());
     }
 
-    public function test_setKind_InvalidKind_ExceptionThrown()
+    public function testSetKind(): void
     {
-        $this->expectException(InvalidKindType::class);
         $zone = new Zone();
+        $zone->setKind('master');
+        $this->assertSame('Master', $zone->getKind());
+
+        $this->expectException(InvalidKindType::class);
+        $this->expectExceptionMessage('Kind must be either Native, Master, Slave. (FooBar given)');
         $zone->setKind('FooBar');
     }
 
-    public function test_setSoaEditApi_InvalidValue_ExceptionThrown()
+    public function testSetSoaEditApi(): void
     {
-        $this->expectException(InvalidSoaEditType::class);
         $zone = new Zone();
+        $zone->setSoaEditApi('increase');
+        $this->assertSame('INCREASE', $zone->getSoaEditApi());
+
+        $this->expectException(InvalidSoaEditType::class);
+        $this->expectExceptionMessage('Kind must be either DEFAULT, INCREASE, EPOCH, SOA-EDIT, SOA-EDIT-INCREASE. (FOOBAR given)');
         $zone->setSoaEditApi('FooBar');
     }
 
-    public function test_setNsec3param_InvalidAlgorithm_ExceptionThrown()
+    public function testSetSoaEdit(): void
+    {
+        $zone = new Zone();
+        $zone->setSoaEdit('inception-increment');
+        $this->assertSame('INCEPTION-INCREMENT', $zone->getSoaEdit());
+
+        $this->expectException(InvalidSoaEditType::class);
+        $this->expectExceptionMessage('Kind must be either INCREMENT-WEEKS, INCEPTION-EPOCH, INCEPTION-INCREMENT, EPOCH, NONE. (FOOBAR given)');
+        $zone->setSoaEdit('FooBar');
+    }
+
+    public function testSetNsec3param(): void
+    {
+        $zone = new Zone();
+        $zone->setNsec3param('1 0 100 f00Bar');
+        $this->assertEquals('1 0 100 f00Bar', $zone->getNsec3param());
+    }
+
+    public function testSetNsec3paramInvalidAlgorithm(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('2 0 100 f00bar');
     }
 
-    public function test_setNsec3param_InvalidFlags_ExceptionThrown()
+    public function testSetNsec3paramInvalidFlags(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('1 2 100 f00bar');
     }
 
-    public function test_setNsec3param_InvalidIteration_ExceptionThrown()
+    public function testSetNsec3paramInvalidIteration(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('1 0 25000 f00bar');
     }
 
-    public function test_setNsec3param_InvalidSalt_ExceptionThrown()
+    public function testSetNsec3paramInvalidSalt(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('1 0 100 '.str_repeat('a', 256));
     }
 
-    public function test_setNsec3param_TooFewArguments_ExceptionThrown()
+    public function testSetNsec3paramTooFewArguments(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('1 0');
     }
 
-    public function test_setNsec3param_InvalidArgument_ExceptionThrown()
+    public function tesSetNsec3paramInvalidArgument(): void
     {
         $this->expectException(InvalidNsec3Param::class);
         $zone = new Zone();
         $zone->setNsec3param('unit-test');
-    }
-
-    public function test_setNsec3param()
-    {
-        $zone = new Zone();
-        $zone->setNsec3param('1 0 100 f00Bar');
-        $this->assertEquals('1 0 100 f00Bar', $zone->getNsec3param());
     }
 }


### PR DESCRIPTION
## Description

Improve NSEC3PARAM validation and prepare new release.
More info about the parameters: https://doc.powerdns.com/authoritative/dnssec/operational.html#setting-the-nsec-modes-and-parameters.