### PR TITLE
Allow to return statistics endpoint data

### DIFF
--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -216,6 +216,16 @@ class Powerdns
     }
 
     /**
+     * Query PowerDNS internal statistics.
+     *
+     * @return mixed[]
+     */
+    public function statistics(): array
+    {
+        return $this->connector->get('statistics');
+    }
+
+    /**
      * Get the PowerDNS server version.
      *
      * @return string The server version.

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -35,6 +35,23 @@ class PowerdnsTest extends TestCase
         $this->assertSame('test-key', $config['apiKey']);
     }
 
+    public function testStatistics(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('get')->withArgs(['statistics'])->once()->andReturn($example = [
+            [
+                'name' => 'corrupt-packets',
+                'type' => 'StatisticItem',
+                'value' => 0,
+            ],
+        ]);
+
+        $powerDns = new Powerdns(null, null, null, null, $connector);
+        $stats = $powerDns->statistics();
+
+        self::assertEquals($example, $stats);
+    }
+
     public function testZone(): void
     {
         $connector = Mockery::mock(Connector::class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow to fetch PowerDNS internal statistics:
https://doc.powerdns.com/authoritative/http-api/statistics.html

## Motivation and context

I would like to be able to extract statistics with this library.

## How has this been tested?

Tested with real PowerDNS instance.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
