### PR TITLE
Get PowerDNS statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.4.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.4.0...develop)
+[Compare v2.5.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.5.0...develop)
+
+## [v2.5.0](https://github.com/exonet/powerdns-php/releases/tag/v2.5.0) - 2020-10-30
+### Added
+- Get PowerDNS statistics.
 
 ## [v2.4.0](https://github.com/exonet/powerdns-php/releases/tag/v2.4.0) - 2020-08-04
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform-check": false
     }
 }

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -217,12 +217,29 @@ class Powerdns
 
     /**
      * Query PowerDNS internal statistics.
+     * The ring statistics are disabled by default to speedup the request and reduce the response size.
      *
-     * @return mixed[]
+     * The $statistics and $includeRings parameters are supported in PowerDNS 4.3 and newer.
+     * On older PowerDNS instances these parameters are ignored.
+     *
+     * @param null|string $statistic    Optional name of a specific statistic to get.
+     * @param bool        $includeRings Include ring statistics or not.
+     *
+     * @return array An array with statistics.
      */
-    public function statistics(): array
+    public function statistics($statistic = null, $includeRings = false): array
     {
-        return $this->connector->get('statistics');
+        // Convert $includeRings param to string.
+        $includeRings = $includeRings ? 'true' : 'false';
+
+        $endpoint = 'statistics?includerings='.$includeRings;
+
+        // Request a specific statistic.
+        if ($statistic) {
+            $endpoint .= '&statistic='.$statistic;
+        }
+
+        return $this->connector->get($endpoint);
     }
 
     /**

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -38,7 +38,7 @@ class PowerdnsTest extends TestCase
     public function testStatistics(): void
     {
         $connector = Mockery::mock(Connector::class);
-        $connector->shouldReceive('get')->withArgs(['statistics'])->once()->andReturn($example = [
+        $connector->shouldReceive('get')->withArgs(['statistics?includerings=false'])->once()->andReturn($example = [
             [
                 'name' => 'corrupt-packets',
                 'type' => 'StatisticItem',
@@ -48,6 +48,23 @@ class PowerdnsTest extends TestCase
 
         $powerDns = new Powerdns(null, null, null, null, $connector);
         $stats = $powerDns->statistics();
+
+        self::assertEquals($example, $stats);
+    }
+
+    public function testStatisticsWithParams(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('get')->withArgs(['statistics?includerings=true&statistic=corrupt-packets'])->once()->andReturn($example = [
+            [
+                'name' => 'corrupt-packets',
+                'type' => 'StatisticItem',
+                'value' => 0,
+            ],
+        ]);
+
+        $powerDns = new Powerdns(null, null, null, null, $connector);
+        $stats = $powerDns->statistics('corrupt-packets', true);
 
         self::assertEquals($example, $stats);
     }


### PR DESCRIPTION
Extended https://github.com/exonet/powerdns-php/pull/45 to support statistics parameters available in PowerDNS 4.3.

Original Pull Request👇


--------

## Description

Allow to fetch PowerDNS internal statistics:
https://doc.powerdns.com/authoritative/http-api/statistics.html

## Motivation and context

I would like to be able to extract statistics with this library.

## How has this been tested?

Tested with real PowerDNS instance.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
