### PR TITLE
Fix providing account-value on new zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - The `account` is send to PowerDNS when creating zone.
 
 ## [v2.5.0](https://github.com/exonet/powerdns-php/releases/tag/v2.5.0) - 2020-10-30
+[Compare v2.4.0 - v2.5.0](https://github.com/exonet/powerdns-php/compare/v2.4.0...v2.5.0)
 ### Added
 - Get PowerDNS statistics.
 
 ## [v2.4.0](https://github.com/exonet/powerdns-php/releases/tag/v2.4.0) - 2020-08-04
+[Compare v2.3.1 - v2.4.0](https://github.com/exonet/powerdns-php/compare/v2.3.1...v2.4.0)
 ### Added
 - Export a zone in AXFR format. (#35)
 - Get the zone from a ResourceRecord. (#40)
@@ -30,6 +32,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - `$resouceRecord->getComments()` no longer throws an exception if there are no comments. (#38)
 
 ## [v2.3.1](https://github.com/exonet/powerdns-php/releases/tag/v2.3.1) - 2020-05-12
+[Compare v2.3.0 - v2.3.1](https://github.com/exonet/powerdns-php/compare/v2.3.0...v2.3.1)
 ### Fixed
 - No longer throw an exception when throwing an exception if the response body is not an error. (#32)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v2.5.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.5.0...develop)
+[Compare v2.5.1 - Unreleased](https://github.com/exonet/powerdns-php/compare/v2.5.1...develop)
+
+## [v2.5.1](https://github.com/exonet/powerdns-php/releases/tag/v2.5.1) - 2020-11-06
+[Compare v2.5.0 - v2.5.1](https://github.com/exonet/powerdns-php/compare/v2.5.0...v2.5.1)
+### Fixed
+- The `account` is send to PowerDNS when creating zone.
 
 ## [v2.5.0](https://github.com/exonet/powerdns-php/releases/tag/v2.5.0) - 2020-10-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## [v2.5.1](https://github.com/exonet/powerdns-php/releases/tag/v2.5.1) - 2020-11-06
 [Compare v2.5.0 - v2.5.1](https://github.com/exonet/powerdns-php/compare/v2.5.0...v2.5.1)
 ### Fixed
-- The `account` is send to PowerDNS when creating zone.
+- The `account` is send to PowerDNS when creating a zone. (#47)
 
 ## [v2.5.0](https://github.com/exonet/powerdns-php/releases/tag/v2.5.0) - 2020-10-30
 [Compare v2.4.0 - v2.5.0](https://github.com/exonet/powerdns-php/compare/v2.4.0...v2.5.0)

--- a/src/Transformers/CreateZoneTransformer.php
+++ b/src/Transformers/CreateZoneTransformer.php
@@ -19,6 +19,7 @@ class CreateZoneTransformer extends Transformer
             'masters' => $this->data->getMasters(),
             'nameservers' => $this->data->getNameservers(),
             'nsec3param' => $this->data->getNsec3param(),
+            'account' => $this->data->getAccount(),
         ];
     }
 }

--- a/tests/functional/AdvancedZoneCreationTest.php
+++ b/tests/functional/AdvancedZoneCreationTest.php
@@ -22,6 +22,7 @@ class AdvancedZoneCreationTest extends FunctionalTestCase
         $newZone->setNameservers(['ns1.test.']);
         $newZone->setApiRectify(false);
         $newZone->setNsec3param('1 0 100 1234567890');
+        $newZone->setAccount('account-name');
 
         // Create a new zone with the defined records and name servers.
         $this->powerdns->createZoneFromResource($newZone);
@@ -38,5 +39,6 @@ class AdvancedZoneCreationTest extends FunctionalTestCase
         $this->assertSame(['ns1.test.'], $zoneResource->getNameservers());
         $this->assertFalse($zoneResource->hasAutoRectify(), 'API Rectify not correctly set.');
         $this->assertSame('1 0 100 1234567890', $zoneResource->getNsec3param());
+        $this->assertSame('account-name', $zoneResource->getAccount());
     }
 }


### PR DESCRIPTION
## Description
Save the DNS zone account.

## Motivation and context
The `account` was not saved to PowerDNS, it is now.

Why is this change required? What problem does it solve?

fixes #47 

## How has this been tested?
Updated the included test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
