### PR TITLE
Updating Guzzle to version 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "~7.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.2",
         "psr/log": "^1.0"
     },
     "require-dev": {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -123,7 +123,7 @@ class Connector
         $stream = $payload !== null ? \GuzzleHttp\Psr7\stream_for($payload) : null;
         $request = new Request($method, $url, $headers, $stream);
 
-        $response = $this->httpClient->send($request);
+        $response = $this->httpClient->send($request, ['http_errors' => false]);
 
         return $this->parseResponse($response);
     }


### PR DESCRIPTION
## Description

We are using this project in another project that has a hard dependency on
a never Guzzle version. As such we upgraded Guzzle and fixed combability
on how Guzzle throws errors in this codebase.

## Motivation and context

As many never projects depends on a never Guzzle we felt that it was motivated to upgrade the Guzzle version to the latest Stable release. And we felt it might be useful to upgrade the base project too. 

## How has this been tested?

We did run the full test suite with the following results: 

RESULTS
----------------------

✓ PHP 7.1 / PDNS: 4.1
✓ PHP 7.1 / PDNS: 4.2
✓ PHP 7.1 / PDNS: 4.3

✓ PHP 7.2 / PDNS: 4.1
✓ PHP 7.2 / PDNS: 4.2
✓ PHP 7.2 / PDNS: 4.3

✓ PHP 7.3 / PDNS: 4.1
✓ PHP 7.3 / PDNS: 4.2
✓ PHP 7.3 / PDNS: 4.3

✓ PHP 7.4 / PDNS: 4.1
✓ PHP 7.4 / PDNS: 4.2
✓ PHP 7.4 / PDNS: 4.3


