### PR TITLE
Added support for PowerDNS API notify call

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -79,14 +79,14 @@ class Connector
     /**
      * Perform a PUT request and return the parsed body as response.
      *
-     * @param string      $urlPath The URL path.
-     * @param Transformer $payload The payload to put.
+     * @param string           $urlPath The URL path.
+     * @param Transformer|null $payload The payload to put.
      *
      * @return mixed[] The response body.
      */
-    public function put(string $urlPath, Transformer $payload): array
+    public function put(string $urlPath, Transformer $payload = null): array
     {
-        return $this->makeCall('PUT', $urlPath, json_encode($payload->transform()));
+        return $this->makeCall('PUT', $urlPath, $payload !== null ? json_encode($payload->transform()) : null);
     }
 
     /**

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -200,7 +200,7 @@ class Zone extends AbstractZone
     }
 
     /**
-     * Send a DNS notify to all the slaves
+     * Send a DNS notify to all the slaves.
      *
      * @return bool True when the DNS notify was successfully sent
      */

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -200,6 +200,22 @@ class Zone extends AbstractZone
     }
 
     /**
+     * Send a DNS notify to all the slaves
+     *
+     * @return bool True when the DNS notify was successfully sent
+     */
+    public function notify(): bool
+    {
+        $result = $this->connector->put($this->getZonePath('/notify'));
+
+        /*
+         * The notify PUT request will return an 200 with no body, so the $result is empty. If this is the case, the PUT was
+         * successful. If there was an error, an exception will be thrown.
+         */
+        return empty($result);
+    }
+
+    /**
      * Enable DNSSEC for this zone.
      *
      * @return bool True when enabled.


### PR DESCRIPTION
## Description
When you have a DNS setup with slaves, you may want to notify the slaves manually. PowerDNS API has a call for it, but it wasn't implemented in this package.
See https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id-notify for the call specification
The changes made to make this work are a new method called `notify` in `src/Zone.php` and the argument for the transformer in the method `put` in `src/Connector.php` has a default value of null. As shown in the PowerDNS API documentation, the no payload must be send.

## Motivation and context
As said in the description. When you have a setup with slaves, you may want to notify them manually if this isn't done automatically. 

## How has this been tested?
After for example a new zone is created call `$powerdns->zone($domain)->notify();` and see if the slaves have the zone available.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

No tests are created or changed. The method `put` in `src/Connector.php` has no tests at all. I can create a test for the notify and mock the response. It does not bring any useful meaning to the test. I assume this is why for example no tests are made for the method `setNsec3param` in the same class. 
Ofcourse if you want a tests, let me know. Perhaps we can find a way to make it a meaningful one.
