### PR TITLE
Added support for /servers/{server_id}/zones query parameter dnssec in PowerDns::listZones

### DIFF
--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -195,7 +195,9 @@ class Powerdns
      * Retrieve all zones.
      *
      * @param bool $omitDnssecAndEditedSerialFields When set to true dnssec and edited_serial are omitted
+     *
      * @return Zone[] Array containing the zones
+     *
      * @link https://doc.powerdns.com/authoritative/http-api/zone.html#get--servers-server_id-zones
      */
     public function listZones(bool $omitDnssecAndEditedSerialFields = false): array
@@ -204,7 +206,7 @@ class Powerdns
             function (array $args) {
                 return new Zone($this->connector, $args['id']);
             },
-            $this->connector->get('zones?dnssec=' . ($omitDnssecAndEditedSerialFields ? 'true': 'false'))
+            $this->connector->get('zones?dnssec='.($omitDnssecAndEditedSerialFields ? 'true': 'false'))
         );
     }
 

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -194,15 +194,17 @@ class Powerdns
     /**
      * Retrieve all zones.
      *
+     * @param bool $omitDnssecAndEditedSerialFields When set to true dnssec and edited_serial are omitted
      * @return Zone[] Array containing the zones
+     * @link https://doc.powerdns.com/authoritative/http-api/zone.html#get--servers-server_id-zones
      */
-    public function listZones(): array
+    public function listZones(bool $omitDnssecAndEditedSerialFields = false): array
     {
         return array_map(
             function (array $args) {
                 return new Zone($this->connector, $args['id']);
             },
-            $this->connector->get('zones')
+            $this->connector->get('zones?dnssec=' . ($omitDnssecAndEditedSerialFields ? 'true': 'false'))
         );
     }
 

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -206,7 +206,7 @@ class Powerdns
             function (array $args) {
                 return new Zone($this->connector, $args['id']);
             },
-            $this->connector->get('zones?dnssec='.($omitDnssecAndEditedSerialFields ? 'true': 'false'))
+            $this->connector->get('zones?dnssec='.($omitDnssecAndEditedSerialFields ? 'true' : 'false'))
         );
     }
 

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -101,7 +101,7 @@ class PowerdnsTest extends TestCase
     public function testListZones(string $dnssecArgument, bool $listZonesArgument): void
     {
         $connector = Mockery::mock(Connector::class);
-        $connector->shouldReceive('get')->withArgs(['zones?dnssec=' . $dnssecArgument])->once()->andReturn(
+        $connector->shouldReceive('get')->withArgs(['zones?dnssec='.$dnssecArgument])->once()->andReturn(
             [
                 [
                     'account' => '',

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -90,10 +90,18 @@ class PowerdnsTest extends TestCase
         $this->assertTrue($powerDns->deleteZone('test.nl.'));
     }
 
-    public function testListZones(): void
+    public function listZonesArgumentDataProvider(): array
+    {
+        return [['true', true], ['false', false]];
+    }
+
+    /**
+     * @dataProvider listZonesArgumentDataProvider
+     */
+    public function testListZones(string $dnssecArgument, bool $listZonesArgument): void
     {
         $connector = Mockery::mock(Connector::class);
-        $connector->shouldReceive('get')->withArgs(['zones'])->once()->andReturn(
+        $connector->shouldReceive('get')->withArgs(['zones?dnssec=' . $dnssecArgument])->once()->andReturn(
             [
                 [
                     'account' => '',
@@ -124,7 +132,7 @@ class PowerdnsTest extends TestCase
 
         $powerDns = new Powerdns(null, null, null, null, $connector);
 
-        $response = $powerDns->listZones();
+        $response = $powerDns->listZones($listZonesArgument);
         $this->assertIsArray($response);
         $this->assertCount(2, $response);
         foreach ($response as $zone) {


### PR DESCRIPTION
Performance improvement for PowerDns::listZones

## Description

By adding support to include `dnssec` query parameter when calling `/servers/{server_id}/zones` you can set this to false to speed up the performance. With 12000 zones for example the time goes from ±8.8 seconds to ±0.9 seconds.

## Motivation and context
See linked issue #60.

## How has this been tested?
The unit test for listZones is changed to test the behaviour.
When comparing the results for dnssec query parameter set to `true` and `false` I couldn't see any difference with my local setup. My knowledge of PowerDNS is limited. So perhaps you can see a differents in the result from PowerDNS API.

## Screenshots (if appropriate)
N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [N/A] If my change requires a change to the documentation, I have updated it accordingly.


