### PR TITLE
Allow unsetting nsec3param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare v3.1.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v3.1.0...develop)
+### Added
+- Added a method `unsetNsec3param()` to unset the nsec3param for a zone.
+- Unit tests for enabling, disabling and setting DNSSEC.
+
 ### Changed
-- Calling `setNsec3Param()` without a value will unset the `nsec3param`.
+- Calling `setNsec3Param()` with value `null` will unset the `nsec3param`.
 
 ### Fixed
 - Updated the stable composer.phar URL to properly run tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare v3.1.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v3.1.0...develop)
+### Changed
+- Calling `setNsec3Param()` without a value will unset the `nsec3param`.
+
+### Fixed
+- Updated the stable composer.phar URL to properly run tests.
 
 ## [v3.1.0](https://github.com/exonet/powerdns-php/releases/tag/v3.1.0) - 2021-02-01
 [Compare v3.0.0 - v3.1.0](https://github.com/exonet/powerdns-php/compare/v2.0.0...v3.1.0)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -46,7 +46,7 @@ SET_PDNS_VERSION=$2
 
 # Grab the most recent stable composer.
 rm -f composer.phar
-curl -L -sS https://getcomposer.org/composer-stable.phar -o composer.phar
+curl -L -sS https://getcomposer.org/download/latest-stable/composer.phar -o composer.phar
 chmod +x composer.phar
 
 # If both arguments are given, only run that combo.

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -333,7 +333,7 @@ class Zone
     /**
      * Set the NSEC3PARAM for this zone.
      *
-     * @param string $nsec3param The NSEC3PARAM value to set.
+     * @param string|null $nsec3param The NSEC3PARAM value to set.
      *
      * @throws InvalidNsec3Param If the hash algorithm is invalid.
      * @throws InvalidNsec3Param If the flags parameter is invalid.
@@ -342,8 +342,15 @@ class Zone
      *
      * @return Zone The current Zone instance.
      */
-    public function setNsec3param(string $nsec3param): self
+    public function setNsec3param(?string $nsec3param = null): self
     {
+        // If set to null, return,
+        if (is_null($nsec3param)) {
+            $this->nsec3param = null;
+
+            return $this;
+        }
+
         // Validate the nsec3param. Set null if the given string has not enough arguments.
         [$algorithm, $flags, $iterations, $salt] = explode(' ', $nsec3param) + [null, null, null, null];
 

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -333,7 +333,7 @@ class Zone
     /**
      * Set the NSEC3PARAM for this zone.
      *
-     * @param string|null $nsec3param The NSEC3PARAM value to set.
+     * @param string|null $nsec3param The NSEC3PARAM value to set or null to unset.
      *
      * @throws InvalidNsec3Param If the hash algorithm is invalid.
      * @throws InvalidNsec3Param If the flags parameter is invalid.
@@ -342,7 +342,7 @@ class Zone
      *
      * @return Zone The current Zone instance.
      */
-    public function setNsec3param(?string $nsec3param = null): self
+    public function setNsec3param(?string $nsec3param): self
     {
         // If set to null, return,
         if (is_null($nsec3param)) {

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -201,6 +201,18 @@ class Zone extends AbstractZone
     }
 
     /**
+     * Unset the NSEC3PARAM for this zone, and save it.
+     *
+     * @throws InvalidNsec3Param If the given param is invalid.
+     *
+     * @return bool True when updated.
+     */
+    public function unsetNsec3param(): bool
+    {
+        return $this->setNsec3param(null);
+    }
+
+    /**
      * Send a DNS notify to all the slaves.
      *
      * @return bool True when the DNS notify was successfully sent
@@ -245,13 +257,7 @@ class Zone extends AbstractZone
      */
     public function setDnssec(bool $state): bool
     {
-        $result = $this->put(new DnssecTransformer(['dnssec' => $state]));
-
-        /*
-         * The PUT request will return an 204 No Content, so the $result is empty. If this is the case, the PATCH was
-         * successful. If there was an error, an exception will be thrown.
-         */
-        return empty($result);
+        return $this->put(new DnssecTransformer(['dnssec' => $state]));
     }
 
     /**

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -182,7 +182,7 @@ class Zone extends AbstractZone
     /**
      * Set an NSEC3PARAM for this zone, and save it.
      *
-     * @param string $nsec3param The NSEC3PARAM value to set.
+     * @param string|null $nsec3param The NSEC3PARAM value to set.
      *
      * @throws InvalidNsec3Param If the hash algorithm is invalid.
      * @throws InvalidNsec3Param If the flags parameter is invalid.
@@ -191,7 +191,7 @@ class Zone extends AbstractZone
      *
      * @return bool True when updated.
      */
-    public function setNsec3param($nsec3param): bool
+    public function setNsec3param(?string $nsec3param = null): bool
     {
         $zone = $this->resource()->setNsec3param($nsec3param);
         $transformer = new Nsec3paramTransformer($zone);

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -2,6 +2,7 @@
 
 namespace Exonet\Powerdns;
 
+use Exonet\Powerdns\Exceptions\InvalidNsec3Param;
 use Exonet\Powerdns\Resources\Record;
 use Exonet\Powerdns\Resources\ResourceRecord;
 use Exonet\Powerdns\Resources\ResourceSet;
@@ -182,7 +183,7 @@ class Zone extends AbstractZone
     /**
      * Set an NSEC3PARAM for this zone, and save it.
      *
-     * @param string|null $nsec3param The NSEC3PARAM value to set.
+     * @param string|null $nsec3param The NSEC3PARAM value to set or null to unset.
      *
      * @throws InvalidNsec3Param If the hash algorithm is invalid.
      * @throws InvalidNsec3Param If the flags parameter is invalid.
@@ -191,7 +192,7 @@ class Zone extends AbstractZone
      *
      * @return bool True when updated.
      */
-    public function setNsec3param(?string $nsec3param = null): bool
+    public function setNsec3param(?string $nsec3param): bool
     {
         $zone = $this->resource()->setNsec3param($nsec3param);
         $transformer = new Nsec3paramTransformer($zone);

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -112,7 +112,7 @@ class ZoneTest extends TestCase
     public function testSetEmptyNsec3param(): void
     {
         $zone = new Zone();
-        $zone->setNsec3param();
+        $zone->setNsec3param(null);
         $this->assertNull($zone->getNsec3param());
     }
 

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -109,6 +109,13 @@ class ZoneTest extends TestCase
         $this->assertEquals('1 0 100 f00Bar', $zone->getNsec3param());
     }
 
+    public function testSetEmptyNsec3param(): void
+    {
+        $zone = new Zone();
+        $zone->setNsec3param();
+        $this->assertNull($zone->getNsec3param());
+    }
+
     public function testSetNsec3paramInvalidAlgorithm(): void
     {
         $this->expectException(InvalidNsec3Param::class);

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -151,6 +151,16 @@ class ZoneTest extends TestCase
         $zone->setNsec3param(null);
     }
 
+    public function testUnsetNsec3param(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $zone = Mockery::mock(Zone::class.'[resource,setNsec3param]', [$connector, 'test.nl'])->makePartial();
+        $zone->shouldReceive('resource')->withNoArgs()->once()->andReturn(new ZoneResource());
+        $zone->shouldReceive('setNsec3param')->withArgs([null])->once()->andReturnTrue();
+
+        $this->assertTrue($zone->unsetNsec3param());
+    }
+
     public function testSetDnssec(): void
     {
         $connector = Mockery::mock(Connector::class);

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -189,7 +189,6 @@ class ZoneTest extends TestCase
     {
         $connector = Mockery::mock(Connector::class);
         $zone = Mockery::mock(Zone::class.'[setDnssec]', [$connector, 'test.nl'])->makePartial();
-        $zone->shouldReceive('resource')->withNoArgs()->once()->andReturn(new ZoneResource());
         $zone->shouldReceive('setDnssec')->withArgs([false])->once()->andReturnTrue();
 
         $this->assertTrue($zone->disableDnssec());

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -151,6 +151,40 @@ class ZoneTest extends TestCase
         $zone->setNsec3param(null);
     }
 
+    public function testSetDnssec(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('put')->withArgs(['zones/test.nl.', Mockery::on(function ($transformer) {
+            $transformed = $transformer->transform();
+            $this->assertTrue($transformed->dnssec);
+
+            return true;
+        })])->once()->andReturn([]);
+        $zone = Mockery::mock(Zone::class.'[resource]', [$connector, 'test.nl'])->makePartial();
+        $zone->shouldReceive('resource')->withNoArgs()->once()->andReturn(new ZoneResource());
+
+        $zone->setDnssec(true);
+    }
+
+    public function testEnableDnssec(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $zone = Mockery::mock(Zone::class.'[setDnssec]', [$connector, 'test.nl'])->makePartial();
+        $zone->shouldReceive('setDnssec')->withArgs([true])->once()->andReturnTrue();
+
+        $this->assertTrue($zone->enableDnssec());
+    }
+
+    public function testDisableDnssec(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $zone = Mockery::mock(Zone::class.'[setDnssec]', [$connector, 'test.nl'])->makePartial();
+        $zone->shouldReceive('resource')->withNoArgs()->once()->andReturn(new ZoneResource());
+        $zone->shouldReceive('setDnssec')->withArgs([false])->once()->andReturnTrue();
+
+        $this->assertTrue($zone->disableDnssec());
+    }
+
     public function testNotify(): void
     {
         $connector = Mockery::mock(Connector::class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes (non-breaking) the signature of `setNsec3Param` to allow unsetting the nsec3param for a zone.

## Motivation and context

Zones without DNSSEC do not support nsec3param, so it needs to be unset.

## How has this been tested?

Unit test has been created, and test it against our dummy DNS.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

