### PR TITLE
Add resource records when creating a new zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare v3.1.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v3.1.0...develop)
+### Added
+- It is now possible to set/get resource records to a zone resource. See the `examples/new_domain_from_zone_resource.php` example.
+
+### Changed
+- The internals of getting ResourceSets. Previously a GET request was made to get the resource sets, now the zone resource is being used which already contains all resource sets.
 
 ## [v3.1.0](https://github.com/exonet/powerdns-php/releases/tag/v3.1.0) - 2021-02-01
 [Compare v3.0.0 - v3.1.0](https://github.com/exonet/powerdns-php/compare/v2.0.0...v3.1.0)

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Exonet\\Powerdns\\": "tests"
+            "Exonet\\Powerdns\\tests\\": "tests"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
+        "dms/phpunit-arraysubset-asserts": "^0.2.1",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^9"
     },

--- a/examples/new_domain_from_zone_resource.php
+++ b/examples/new_domain_from_zone_resource.php
@@ -20,6 +20,8 @@ $dnsRecords = [
 
     ['name' => '@', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
     ['name' => 'www', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+    // In this example a SOA record with custom nameserver and admin-contact will be used.
+    ['name' => '@', 'type' => RecordType::SOA, 'content' => 'ns1.custom. hostmaster.custom. 0 10800 3605 604800 3600', 'ttl' => 60],
 ];
 
 // Update the key to the real PowerDNS API Key.
@@ -42,6 +44,8 @@ $newZone->setSoaEditApi('epoch');
 $newZone->setNameservers($nameServers);
 $newZone->setApiRectify(false);
 $newZone->setNsec3param('1 0 100 1234567890');
+// Set the DNS records that must be created together with the zone.
+$newZone->setResourceRecords($dnsRecords);
 
 // Create a new zone with the defined records and name servers.
-$powerdns->createZoneFromResource($newZone)->create($dnsRecords);
+$powerdns->createZoneFromResource($newZone);

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,8 +27,8 @@ run() {
         -v "$PWD":/usr/src \
         -v "$PWD"/composer.phar:/usr/src/composer.phar \
         -w /usr/src/ \
-        php:"$PHP_VERSION"-cli \
-        bash -c './composer.phar -n update && php ./vendor/bin/phpunit'
+        php:"$PHP_VERSION"-alpine \
+        ash -c './composer.phar -n update && php ./vendor/bin/phpunit'
 
     if [ $? -eq 0 ]; then
         RESULTS="$RESULTS\n${green}✓ PHP $PHP_VERSION / PDNS: $PDNS_VERSION"

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Exonet\Powerdns;
+
+use Exonet\Powerdns\Resources\Record;
+use Exonet\Powerdns\Resources\ResourceRecord;
+
+class Helper
+{
+    /**
+     * Make a new resource record based on the arguments or an array with data.
+     *
+     * @param string|array $name The resource record name or an array with the data.
+     * @param string       $type The type of the resource record.
+     * @param string       $content The content of the resource record.
+     * @param int          $ttl The TTL.
+     *
+     * @throws Exceptions\InvalidRecordType If the given type is invalid.
+     *
+     * @return ResourceRecord The constructed ResourceRecord.
+     */
+    static function createResourceRecord(
+        string $zoneName,
+        $name,
+        string $type = '',
+        $content = '',
+        int $ttl = 3600
+    ): ResourceRecord {
+        if (is_array($name)) {
+            if (isset($name['records'])) {
+                return (new ResourceRecord())->setApiResponse($name);
+            }
+
+            ['name' => $name, 'type' => $type, 'ttl' => $ttl, 'content' => $content] = $name;
+        }
+
+        $name = str_replace('@', $zoneName, $name);
+
+        // If the name of the record doesn't end in the zone name, append the zone name to it.
+        if (substr($name, -strlen($zoneName)) !== $zoneName) {
+            $name = sprintf('%s.%s', $name, $zoneName);
+        }
+
+        $resourceRecord = new ResourceRecord();
+        $resourceRecord
+            ->setChangeType('replace')
+            ->setName($name)
+            ->setType($type)
+            ->setTtl($ttl);
+
+        if (is_string($content)) {
+            $content = [$content];
+        }
+
+        $recordList = [];
+        foreach ($content as $record) {
+            $recordItem = new Record();
+
+            if (is_string($record)) {
+                $recordItem->setContent($record);
+            } else {
+                $recordItem->setContent($record['content']);
+                if (isset($record['disabled'])) {
+                    $recordItem->setDisabled($record['disabled']);
+                }
+            }
+
+            $recordList[] = $recordItem;
+        }
+
+        $resourceRecord->setRecords($recordList);
+
+        return $resourceRecord;
+    }
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -10,10 +10,11 @@ class Helper
     /**
      * Make a new resource record based on the arguments or an array with data.
      *
-     * @param string|array $name    The resource record name or an array with the data.
-     * @param string       $type    The type of the resource record.
-     * @param string       $content The content of the resource record.
-     * @param int          $ttl     The TTL.
+     * @param string       $zoneName The zone name for this resource record.
+     * @param string|array $name     The resource record name or an array with the data.
+     * @param string       $type     The type of the resource record.
+     * @param string|array $content  The content of the resource record.
+     * @param int          $ttl      The TTL.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -10,16 +10,16 @@ class Helper
     /**
      * Make a new resource record based on the arguments or an array with data.
      *
-     * @param string|array $name The resource record name or an array with the data.
-     * @param string       $type The type of the resource record.
+     * @param string|array $name    The resource record name or an array with the data.
+     * @param string       $type    The type of the resource record.
      * @param string       $content The content of the resource record.
-     * @param int          $ttl The TTL.
+     * @param int          $ttl     The TTL.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *
      * @return ResourceRecord The constructed ResourceRecord.
      */
-    static function createResourceRecord(
+    public static function createResourceRecord(
         string $zoneName,
         $name,
         string $type = '',

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -7,6 +7,7 @@ namespace Exonet\Powerdns\Resources;
 use Exonet\Powerdns\Exceptions\InvalidKindType;
 use Exonet\Powerdns\Exceptions\InvalidNsec3Param;
 use Exonet\Powerdns\Exceptions\InvalidSoaEditType;
+use Exonet\Powerdns\Helper;
 
 class Zone
 {
@@ -73,6 +74,11 @@ class Zone
     private $nameservers = [];
 
     /**
+     * @var ResourceRecord[] The resource records for this zone.
+     */
+    private $resourceRecords = [];
+
+    /**
      * Set the zone data based on the API response.
      *
      * @param mixed[] $data The API response.
@@ -92,6 +98,7 @@ class Zone
         $this->soaEditApi = !empty($data['soa_edit_api']) ? $data['soa_edit_api'] : null;
         $this->apiRectify = $data['api_rectify'];
         $this->account = !empty($data['account']) ? $data['account'] : null;
+        $this->setResourceRecords($data['rrsets'] ?? []);
 
         // Try setting the nameservers.
         if (isset($data['rrsets'])) {
@@ -454,6 +461,35 @@ class Zone
     public function setAccount(string $account): self
     {
         $this->account = $account;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource records for this zone.
+     *
+     * @return ResourceRecord[] The resource records.
+     */
+    public function getResourceRecords(): array
+    {
+        return $this->resourceRecords;
+    }
+
+    /**
+     * Set the resource records. These will be transformed to a ResourceRecord instance.
+     *
+     * @param array $resourceRecords The resource records.
+     *
+     * @return $this The current Zone instance.
+     */
+    public function setResourceRecords(array $resourceRecords): self
+    {
+        $rrSets = [];
+        foreach ($resourceRecords as $resourceSet) {
+            $rrSets[] = Helper::createResourceRecord($this->name, $resourceSet);
+        }
+
+        $this->resourceRecords = $rrSets;
 
         return $this;
     }

--- a/src/Transformers/CreateZoneTransformer.php
+++ b/src/Transformers/CreateZoneTransformer.php
@@ -20,6 +20,19 @@ class CreateZoneTransformer extends Transformer
             'nameservers' => $this->data->getNameservers(),
             'nsec3param' => $this->data->getNsec3param(),
             'account' => $this->data->getAccount(),
+            'rrsets' => $this->transformResourceSets(),
         ];
+    }
+
+    /**
+     * Transform the zone ResourceRecords to an array formatted as rrsets.
+     *
+     * @return array The transformed rrsets.
+     */
+    private function transformResourceSets()
+    {
+        $rrSetTransformer = new RRSetTransformer($this->data->getResourceRecords());
+
+        return $rrSetTransformer->transform()->rrsets;
     }
 }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace Exonet\Powerdns\tests;
+
+use Exonet\Powerdns\Helper;
+use Exonet\Powerdns\RecordType;
+use PHPUnit\Framework\TestCase;
+
+class HelperTest extends TestCase
+{
+    public function testWithArguments(): void
+    {
+        $result = Helper::createResourceRecord('unit.test.', 'www', RecordType::A, '127.0.0.1', 1337);
+
+        self::assertSame('www.unit.test.', $result->getName());
+        self::assertSame('A', $result->getType());
+        self::assertSame(1337, $result->getTtl());
+        self::assertCount(1, $result->getRecords());
+        self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
+    }
+
+    public function testWithArray(): void
+    {
+        $result = Helper::createResourceRecord(
+            'unit.test.',
+            [
+                'name' => '@',
+                'type' => RecordType::A,
+                'content' => ['127.0.0.1', '127.0.0.2'],
+                'ttl' => 1337,
+            ]
+        );
+
+        self::assertSame('unit.test.', $result->getName());
+        self::assertSame('A', $result->getType());
+        self::assertSame(1337, $result->getTtl());
+        self::assertCount(2, $result->getRecords());
+        self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
+        self::assertSame('127.0.0.2', $result->getRecords()[1]->getContent());
+    }
+
+    public function testWithApiResponse(): void
+    {
+        foreach(ZoneTest::API_RESPONSE['rrsets'] as $rrset) {
+            $results[] = Helper::createResourceRecord('test.nl.', $rrset);
+        }
+
+        self::assertCount(2, $results);
+
+        self::assertSame('record01.test.nl.', $results[0]->getName());
+        self::assertSame('A', $results[0]->getType());
+        self::assertSame(3600, $results[0]->getTtl());
+        self::assertCount(1, $results[0]->getRecords());
+        self::assertSame('127.0.0.1', $results[0]->getRecords()[0]->getContent());
+
+        self::assertSame('record02.test.nl.', $results[1]->getName());
+        self::assertSame('MX', $results[1]->getType());
+        self::assertSame(3600, $results[1]->getTtl());
+        self::assertCount(1, $results[0]->getRecords());
+        self::assertSame('10 mail01.test.nl.', $results[1]->getRecords()[0]->getContent());
+        self::assertSame('10 mail02.test.nl.', $results[1]->getRecords()[1]->getContent());
+    }
+}

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Exonet\Powerdns\tests;
 
 use Exonet\Powerdns\Helper;
@@ -42,7 +41,7 @@ class HelperTest extends TestCase
 
     public function testWithApiResponse(): void
     {
-        foreach(ZoneTest::API_RESPONSE['rrsets'] as $rrset) {
+        foreach (ZoneTest::API_RESPONSE['rrsets'] as $rrset) {
             $results[] = Helper::createResourceRecord('test.nl.', $rrset);
         }
 

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -10,16 +10,27 @@ use PHPUnit\Framework\TestCase;
 
 class ZoneTest extends TestCase
 {
-    private const API_RESPONSE = [
+    public const API_RESPONSE = [
+        'name' => 'test.nl.',
+        'kind' => 'Native',
+        'serial' => 123,
+        'notified_serial' => 123,
+        'masters' => [],
+        'dnssec' => false,
+        'api_rectify' => true,
         'rrsets' => [
             [
                 'name' => 'record01.test.nl.',
                 'type' => 'A',
+                'ttl' => 3600,
+                'comments' => [],
                 'records' => [['content' => '127.0.0.1', 'disabled' => false]],
             ],
             [
                 'name' => 'record02.test.nl.',
                 'type' => 'MX',
+                'ttl' => 3600,
+                'comments' => [],
                 'records' => [
                     ['content' => '10 mail01.test.nl.', 'disabled' => false],
                     ['content' => '10 mail02.test.nl.', 'disabled' => false],

--- a/tests/functional/AdvancedZoneCreationTest.php
+++ b/tests/functional/AdvancedZoneCreationTest.php
@@ -2,7 +2,6 @@
 
 namespace Exonet\Powerdns\tests\functional;
 
-use Exonet\Powerdns\functional\FunctionalTestCase;
 use Exonet\Powerdns\Resources\Zone as ZoneResource;
 
 class AdvancedZoneCreationTest extends FunctionalTestCase

--- a/tests/functional/FunctionalTestCase.php
+++ b/tests/functional/FunctionalTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Exonet\Powerdns\functional;
+namespace Exonet\Powerdns\tests\functional;
 
 use Exonet\Powerdns\Powerdns;
 use PHPUnit\Framework\TestCase;

--- a/tests/functional/GitHub38Test.php
+++ b/tests/functional/GitHub38Test.php
@@ -2,8 +2,6 @@
 
 namespace Exonet\Powerdns\tests\functional;
 
-use Exonet\Powerdns\functional\FunctionalTestCase;
-
 /**
  * Test scenario for https://github.com/exonet/powerdns-php/issues/38.
  */

--- a/tests/functional/ValidateSOAIncrementTest.php
+++ b/tests/functional/ValidateSOAIncrementTest.php
@@ -2,7 +2,6 @@
 
 namespace Exonet\Powerdns\tests\functional;
 
-use Exonet\Powerdns\functional\FunctionalTestCase;
 use Exonet\Powerdns\RecordType;
 
 class ValidateSOAIncrementTest extends FunctionalTestCase

--- a/tests/functional/ZoneRecordsTest.php
+++ b/tests/functional/ZoneRecordsTest.php
@@ -79,7 +79,6 @@ class ZoneRecordsTest extends FunctionalTestCase
                         $content = str_replace(date('Ymd').'01', '0', $content);
                     }
 
-
                     $name = rtrim(str_replace($this->canonicalName, '', $item->getName()), '.');
                     $createdRecords[] = [
                         'name' => $name === '' ? '@' : $name,

--- a/tests/functional/ZoneRecordsTest.php
+++ b/tests/functional/ZoneRecordsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Exonet\Powerdns\tests\functional;
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Exonet\Powerdns\RecordType;
+use Exonet\Powerdns\Resources\ResourceRecord;
+use Exonet\Powerdns\Resources\ResourceSet;
+use Exonet\Powerdns\Resources\Zone as ZoneResource;
+
+class ZoneRecordsTest extends FunctionalTestCase
+{
+    use ArraySubsetAsserts;
+
+    private $canonicalName;
+
+    private $dnsRecords = [
+        ['name' => 'www', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+        ['name' => 'www', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60],
+        ['name' => 'bla', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+        ['name' => '@', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+        [
+            'name' => '@',
+            'type' => RecordType::SOA,
+            'content' => 'ns1.test. hostmaster.test. 0 10800 3605 604800 3600',
+            'ttl' => 60,
+        ],
+        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns1.powerdns-php.', 'ttl' => 60],
+        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns2.powerdns-php.', 'ttl' => 60],
+        ['name' => '@', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60],
+    ];
+
+    public function testCreateZoneFromResource(): void
+    {
+        // Create a new zone resource.
+        $newZone = new ZoneResource();
+        $newZone->setName($this->canonicalName);
+
+        $newZone->setResourceRecords($this->dnsRecords);
+
+        // Create a new zone with the defined records and name servers.
+        $zone = $this->powerdns->createZoneFromResource($newZone);
+
+        $this->validateResourceSet($zone->get());
+    }
+
+    /**
+     * In the defined DNS records the SOA record differs from the default. Validate that it is working as expected.
+     *
+     * @depends testCreateZoneFromResource
+     */
+    public function testCustomSoa(): void
+    {
+        $soaRecord = $this->powerdns->zone($this->canonicalName)->get(RecordType::SOA)[0]->getRecords()[0]->getContent();
+        self::assertSame('ns1.test. hostmaster.test. '.date('Ymd').'01 10800 3605 604800 3600', $soaRecord);
+
+        $createResult = $this->powerdns->zone($this->canonicalName)->create('new', RecordType::TXT, '"soa update test"');
+        self::assertTrue($createResult);
+
+        $soaRecord = $this->powerdns->zone($this->canonicalName)->get(RecordType::SOA)[0]->getRecords()[0]->getContent();
+        self::assertSame('ns1.test. hostmaster.test. '.date('Ymd').'02 10800 3605 604800 3600', $soaRecord);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->canonicalName = 'zone-with-records.'.time().'.test.';
+    }
+
+    private function validateResourceSet(ResourceSet $resourceSet): void
+    {
+        $createdRecords = [];
+        $resourceSet->map(
+            function (ResourceRecord $item) use (&$createdRecords) {
+                foreach ($item->getRecords() as $recordContent) {
+                    $content = $recordContent->getContent();
+
+                    if ($item->getType() === RecordType::SOA) {
+                        $content = str_replace(date('Ymd').'01', '0', $content);
+                    }
+
+
+                    $name = rtrim(str_replace($this->canonicalName, '', $item->getName()), '.');
+                    $createdRecords[] = [
+                        'name' => $name === '' ? '@' : $name,
+                        'type' => $item->getType(),
+                        'content' => $content,
+                        'ttl' => $item->getTtl(),
+                    ];
+                }
+            }
+        );
+
+        self::assertArraySubset($this->dnsRecords, $createdRecords);
+    }
+}

--- a/tests/functional/ZoneTest.php
+++ b/tests/functional/ZoneTest.php
@@ -2,8 +2,6 @@
 
 namespace Exonet\Powerdns\tests\functional;
 
-use Exonet\Powerdns\functional\FunctionalTestCase;
-
 class ZoneTest extends FunctionalTestCase
 {
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It is now possible to set/get resource records to a zone resource. See the `examples/new_domain_from_zone_resource.php` example.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
