### PR TITLE
Added docker service for PowerDNS 4.4

### DIFF
--- a/.docker/powerdns44/pdns.conf
+++ b/.docker/powerdns44/pdns.conf
@@ -1,0 +1,20 @@
+setuid=pdns
+setgid=pdns
+
+launch=gmysql
+gmysql-dnssec
+
+api=yes
+api-key=apiKey
+
+webserver=yes
+webserver-port=8081
+webserver-address=0.0.0.0
+webserver-allow-from=0.0.0.0/0,::/0
+
+default-soa-content=ns1.powerdns-php. hostmaster.powerdns-php. 20210602 10800 3600 604800 3600
+
+default-ksk-algorithm=rsasha256
+default-ksk-size=2048
+default-zsk-algorithm=rsasha256
+default-zsk-size=1024

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,23 @@ services:
         restart: unless-stopped
         environment:
             MYSQL_ROOT_PASSWORD: verySecretPassword
+
+    powerdns44:
+        image: psitrax/powerdns:latest
+        container_name: pdns44
+        environment:
+            MYSQL_USER: root
+            MYSQL_PASS: verySecretPassword
+            MYSQL_HOST: db-pdns44
+        depends_on:
+            - db-pdns44
+        ports:
+            - 8044:8081
+        volumes:
+            - ./.docker/powerdns44:/etc/pdns/conf.d
+
+    db-pdns44:
+        image: mysql:5.7
+        restart: unless-stopped
+        environment:
+            MYSQL_ROOT_PASSWORD: verySecretPassword

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,14 +55,14 @@ if [ "$#" -eq 2 ]; then
 else
     # Run tests for all supported PHP 7 / PowerDNS 4 combinations.
     for phpversion in {3..4}; do
-        for pdnsversion in {1..3}; do
+        for pdnsversion in {1..4}; do
             run "7.$phpversion" "4.$pdnsversion"
         done
         RESULTS="$RESULTS\n"
     done
     # Run tests for all supported PHP 8 / PowerDNS 4 combinations.
     for phpversion in {0..0}; do
-        for pdnsversion in {1..3}; do
+        for pdnsversion in {1..4}; do
             run "8.$phpversion" "4.$pdnsversion"
         done
         RESULTS="$RESULTS\n"


### PR DESCRIPTION
Extended the docker-compose.yml for PowerDNS 4.4

## Description

The docker hub https://hub.docker.com/r/psitrax/powerdns does not have a tag for PowerDNS 4.4, but the tag `latest` has the correct version. 
The pdns.conf is different in 4.4. The fields `default-soa-name` and `default-soa-email` are removed and replaced by `default-soa-content`.

It is best to use the tag 4.4 when it becomes available. For now this will at least prove that the code works for PowerDNS 4.4.

## Motivation and context
I would love to have support for PowerDNS 4.4

fixes #66 

## How has this been tested?

By running `run-tests.sh`

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [n/a] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
