### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [v3.4.0](https://github.com/exonet/powerdns-php/releases/tag/v3.4.0) - 2021-10-06
 [Compare v3.3.1 - v3.4.0](https://github.com/exonet/powerdns-php/compare/v3.3.1...v3.4.0)
+### Changed
+- The private methods in the `Connector` class are now protected instead of private.
+
 ### Fixed
 - Filling the `SearchResult` resource no longer results in 'Undefined index' notices. (#78)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `powerdns-php` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v3.3.1 - Unreleased](https://github.com/exonet/powerdns-php/compare/v3.3.1...develop)
+[Compare v3.4.0 - Unreleased](https://github.com/exonet/powerdns-php/compare/v3.4.0...develop)
+
+## [v3.4.0](https://github.com/exonet/powerdns-php/releases/tag/v3.4.0) - 2021-10-06
+[Compare v3.3.1 - v3.4.0](https://github.com/exonet/powerdns-php/compare/v3.3.1...v3.4.0)
+### Fixed
+- Filling the `SearchResult` resource no longer results in 'Undefined index' notices. (#78)
 
 ## [v3.3.1](https://github.com/exonet/powerdns-php/releases/tag/v3.3.1) - 2021-07-06
 [Compare v3.3.0 - v3.3.1](https://github.com/exonet/powerdns-php/compare/v3.3.0...v3.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [v3.4.0](https://github.com/exonet/powerdns-php/releases/tag/v3.4.0) - 2021-10-06
 [Compare v3.3.1 - v3.4.0](https://github.com/exonet/powerdns-php/compare/v3.3.1...v3.4.0)
+### Added
+- The `overwriteConnector` method in the Powerdns class.
+
 ### Changed
 - The private methods in the `Connector` class are now protected instead of private.
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -114,7 +114,7 @@ class Connector implements ConnectorInterface
      *
      * @return mixed[] The decoded JSON response.
      */
-    private function makeCall(string $method, string $urlPath, ?string $payload = null): array
+    protected function makeCall(string $method, string $urlPath, ?string $payload = null): array
     {
         $url = $this->buildUrl($urlPath);
         $headers = $this->getDefaultHeaders();
@@ -139,7 +139,7 @@ class Connector implements ConnectorInterface
      *
      * @return mixed[] The decoded JSON response.
      */
-    private function parseResponse(PsrResponse $response): array
+    protected function parseResponse(PsrResponse $response): array
     {
         $this->powerdns->log()->debug('Request completed', ['statusCode' => $response->getStatusCode()]);
         $contents = json_decode($response->getBody()->getContents(), true);
@@ -170,7 +170,7 @@ class Connector implements ConnectorInterface
      *
      * @return string The complete URL.
      */
-    private function buildUrl(string $path): string
+    protected function buildUrl(string $path): string
     {
         $config = $this->powerdns->getConfig();
 
@@ -191,7 +191,7 @@ class Connector implements ConnectorInterface
      *
      * @return string[] The headers.
      */
-    private function getDefaultHeaders(): array
+    protected function getDefaultHeaders(): array
     {
         return [
             'X-API-Key' => $this->powerdns->getConfig()['apiKey'],

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -92,6 +92,20 @@ class Powerdns implements PowerdnsInterface
     }
 
     /**
+     * Overwrite the configured connector instance with the provided one.
+     *
+     * @param ConnectorInterface $connector The new connector instance to use.
+     *
+     * @return $this The current Powerdns class.
+     */
+    public function overwriteConnector(ConnectorInterface $connector): self
+    {
+        $this->connector = $connector;
+
+        return $this;
+    }
+
+    /**
      * Configure a new connection to a PowerDNS server.
      *
      * @param string $host   The PowerDNS host. Must include protocol (http, https, etc.).

--- a/src/Resources/SearchResult.php
+++ b/src/Resources/SearchResult.php
@@ -5,12 +5,12 @@ namespace Exonet\Powerdns\Resources;
 class SearchResult
 {
     /**
-     * @var string The content.
+     * @var string|null The content.
      */
     private $content;
 
     /**
-     * @var bool True when disabled.
+     * @var bool|null True when disabled.
      */
     private $disabled;
 
@@ -30,17 +30,17 @@ class SearchResult
     private $zoneId;
 
     /**
-     * @var string The zone.
+     * @var string|null The zone.
      */
     private $zone;
 
     /**
-     * @var string The record type.
+     * @var string|null The record type.
      */
     private $type;
 
     /**
-     * @var int The TTL value.
+     * @var int|null The TTL value.
      */
     private $ttl;
 
@@ -59,9 +59,9 @@ class SearchResult
     /**
      * Get the content.
      *
-     * @return string The content.
+     * @return string|null The content.
      */
-    public function getContent(): string
+    public function getContent(): ?string
     {
         return $this->content;
     }
@@ -69,9 +69,9 @@ class SearchResult
     /**
      * Get the disabled state.
      *
-     * @return bool True when disabled.
+     * @return bool|null True when disabled.
      */
-    public function isDisabled(): bool
+    public function isDisabled(): ?bool
     {
         return $this->disabled;
     }
@@ -109,9 +109,9 @@ class SearchResult
     /**
      * Get the zone name.
      *
-     * @return string The zone.
+     * @return string|null The zone.
      */
-    public function getZone(): string
+    public function getZone(): ?string
     {
         return $this->zone;
     }
@@ -119,9 +119,9 @@ class SearchResult
     /**
      * Get the record type.
      *
-     * @return string The record type.
+     * @return string|null The record type.
      */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }
@@ -129,9 +129,9 @@ class SearchResult
     /**
      * Get the record Time To Live (TTL).
      *
-     * @return int The TTL.
+     * @return int|null The TTL.
      */
-    public function getTtl(): int
+    public function getTtl(): ?int
     {
         return $this->ttl;
     }
@@ -145,13 +145,13 @@ class SearchResult
      */
     public function setFromApiResponse(array $data): self
     {
-        $this->content = $data['content'];
-        $this->disabled = (bool) $data['disabled'];
+        $this->content = $data['content'] ?? null;
+        $this->disabled = isset($data['disabled']) ? (bool) $data['disabled'] : null;
         $this->name = $data['name'];
         $this->objectType = $data['object_type'];
-        $this->ttl = (int) $data['ttl'];
-        $this->type = $data['type'];
-        $this->zone = $data['zone'];
+        $this->ttl = isset($data['ttl']) ? (int) $data['ttl'] : null;
+        $this->type = $data['type'] ?? null;
+        $this->zone = $data['zone'] ?? null;
         $this->zoneId = $data['zone_id'];
 
         return $this;

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -162,7 +162,8 @@ class PowerdnsTest extends TestCase
                 ]
             );
 
-        $powerDns = new Powerdns(null, null, null, null, $connector);
+        $powerDns = new Powerdns();
+        $powerDns->overwriteConnector($connector);
 
         $searchResults = $powerDns->search('search strïng&more', 1337, 'zone');
 


### PR DESCRIPTION
## Description

Fixes #78 
Closes #77 

```
### Added
- The `overwriteConnector` method in the Powerdns class.

### Changed
- The private methods in the `Connector` class are now protected instead of private.

### Fixed
- Filling the `SearchResult` resource no longer results in 'Undefined index' notices. (#78)
```