### PR TITLE
Update default port to 8081

### DIFF
--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -35,7 +35,7 @@ class Powerdns implements PowerdnsInterface
     /**
      * @var int The PowerDNS API Port.
      */
-    private $port = 8001;
+    private $port = 8081;
 
     /**
      * @var string The PowerDNS API key.
@@ -114,7 +114,7 @@ class Powerdns implements PowerdnsInterface
      *
      * @return PowerdnsInterface The created PowerDNS client.
      */
-    public function connect(string $host, int $port = 8001, string $server = 'localhost'): PowerdnsInterface
+    public function connect(string $host, int $port = 8081, string $server = 'localhost'): PowerdnsInterface
     {
         $this->host = $host;
         $this->port = $port;

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -15,7 +15,7 @@ class Powerdns implements PowerdnsInterface
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v3.3.0';
+    public const CLIENT_VERSION = 'v4.0.0';
 
     /**
      * @var Powerdns The client instance.

--- a/src/PowerdnsInterface.php
+++ b/src/PowerdnsInterface.php
@@ -19,7 +19,7 @@ interface PowerdnsInterface
      *
      * @return Powerdns The created PowerDNS client.
      */
-    public function connect(string $host, int $port = 8001, string $server = 'localhost'): self;
+    public function connect(string $host, int $port = 8081, string $server = 'localhost'): self;
 
     /**
      * Set the authorization key to use for each request.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This changes the default port to 8081, the default port used by [PowerDNS](https://doc.powerdns.com/authoritative/http-api/index.html#webserver)


## Motivation and context

When this library was first created, the [docs](https://github.com/PowerDNS/pdns/pull/7464) of powerdns referenced the wrong port, it is time to correct this in the library as well :-)

Closes #84 
Fixes #36 

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have added the appropriate labels to my pull request (e.g. breaking-change, new-feature, bugfix).
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
