### PR TITLE
Use variables that make sense in examples

### DIFF
--- a/examples/list_records_for_zone.php
+++ b/examples/list_records_for_zone.php
@@ -20,23 +20,23 @@ $powerdns = new Powerdns('127.0.0.1', 'very_secret_secret');
 echo PHP_EOL;
 
 // Get all the resource records for the specified zone/domain.
-$zoneResourceSets = $powerdns->zone($domain)->get();
+$zoneResourceRecords = $powerdns->zone($domain)->get();
 
 // Loop through all found resource records.
-foreach ($zoneResourceSets as $resourceSet) {
+foreach ($zoneResourceRecords as $resourceRecord) {
     /*
-     * A resource set can contain multiple records. By mapping them it is possible
+     * A resource record can contain multiple records. By mapping them it is possible
      * to extract only the content, which is the only necessary information for this example.
      */
     $recordContents = array_map(function (Record $record) {
         return $record->getContent();
-    }, $resourceSet->getRecords());
+    }, $resourceRecord->getRecords());
 
-    // Show for each resource set in the zone the type, name and values.
+    // Echo the type, name and content.
     echo sprintf(
         '| %-4s | %30s --> %-30s%s',
-        $resourceSet->getType(),
-        $resourceSet->getName(),
+        $resourceRecord->getType(),
+        $resourceRecord->getName(),
         implode(', ', $recordContents),
         PHP_EOL
     );


### PR DESCRIPTION
## Description

Renamed variables to something that makes more sense.

## Motivation and context

Variable names used in example were confusing.
