### PR TITLE
Add `setSoaEdit` and `setSoaEditApi` methods to Zone class

### DIFF
--- a/src/Transformers/SoaEditApiTransformer.php
+++ b/src/Transformers/SoaEditApiTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class SoaEditApiTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        return (object) [
+            'soa_edit_api' => $this->data['soa_edit_api'],
+        ];
+    }
+}

--- a/src/Transformers/SoaEditTransformer.php
+++ b/src/Transformers/SoaEditTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class SoaEditTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        return (object) [
+            'soa_edit' => $this->data['soa_edit'],
+        ];
+    }
+}

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -252,9 +252,9 @@ class Zone extends AbstractZone
     }
 
     /**
-     * Set a new value for the SOA_EDIT setting for this zone
+     * Set a new value for the SOA_EDIT setting for this zone.
      *
-     * @param string $value New value for the soa_edit meta setting
+     * @param string $value New value for the soa_edit meta setting.
      *
      * @return bool True when the request succeeded.
      */
@@ -264,9 +264,9 @@ class Zone extends AbstractZone
     }
 
     /**
-     * Set a new value for the SOA_EDIT_API setting for this zone
+     * Set a new value for the SOA_EDIT_API setting for this zone.
      *
-     * @param string $value New value for the soa_edit_api meta setting
+     * @param string $value New value for the soa_edit_api meta setting.
      *
      * @return bool True when the request succeeded.
      */

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -10,6 +10,7 @@ use Exonet\Powerdns\Transformers\DnssecTransformer;
 use Exonet\Powerdns\Transformers\Nsec3paramTransformer;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
 use Exonet\Powerdns\Transformers\SoaEditApiTransformer;
+use Exonet\Powerdns\Transformers\SoaEditTransformer;
 use Exonet\Powerdns\Transformers\Transformer;
 
 class Zone extends AbstractZone
@@ -251,9 +252,21 @@ class Zone extends AbstractZone
     }
 
     /**
+     * Set a new value for the SOA_EDIT setting for this zone
+     *
+     * @param string $value New value for the soa_edit meta setting
+     *
+     * @return bool True when the request succeeded.
+     */
+    public function setSoaEdit(string $value): bool
+    {
+        return $this->put(new SoaEditTransformer(['soa_edit' => $value]));
+    }
+
+    /**
      * Set a new value for the SOA_EDIT_API setting for this zone
      *
-     * @param string $value New value for the soa_edit_api meta setting, empty string to delete
+     * @param string $value New value for the soa_edit_api meta setting
      *
      * @return bool True when the request succeeded.
      */

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -9,6 +9,7 @@ use Exonet\Powerdns\Resources\ResourceSet;
 use Exonet\Powerdns\Transformers\DnssecTransformer;
 use Exonet\Powerdns\Transformers\Nsec3paramTransformer;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
+use Exonet\Powerdns\Transformers\SoaEditApiTransformer;
 use Exonet\Powerdns\Transformers\Transformer;
 
 class Zone extends AbstractZone
@@ -247,5 +248,17 @@ class Zone extends AbstractZone
     public function dnssec(): Cryptokey
     {
         return new Cryptokey($this->connector, $this->zone);
+    }
+
+    /**
+     * Set a new value for the SOA_EDIT_API setting for this zone
+     *
+     * @param string $value New value for the soa_edit_api meta setting, empty string to delete
+     *
+     * @return bool True when the request succeeded.
+     */
+    public function setSoaEditApi(string $value): bool
+    {
+        return $this->put(new SoaEditApiTransformer(['soa_edit_api' => $value]));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the setSoaEdit and setSoaEditApi methods to the Zone class to be able to set the soa_edit and soa_edit_api domain metadata.

## Motivation and context

Doesn't fix an open issue, just adding an extra feature

## How has this been tested?

New methods tested on a live PowerDNS server v4.6

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have added the appropriate labels to my pull request (e.g. breaking-change, new-feature, bugfix).
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
