### PR TITLE
Return short name (without domainname) on $short is true (default false)

### DIFF
--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -233,11 +233,20 @@ class ResourceRecord
      *
      * @return string The name.
      */
-    public function getName(): string
+    public function getName( bool $short = false ): string
     {
-        return $this->name;
-    }
+        $name = $this->name;
 
+        if( $short ) {
+            $name = substr( $this->name, 0, -( strlen( $this->zone->getCanonicalName() ) + 1 ) );
+
+            if( strlen( $name ) == 0 )
+                $name = "@";
+        }
+
+        return $name;
+    }
+    
     /**
      * Set the name of the resource record.
      *

--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -233,20 +233,21 @@ class ResourceRecord
      *
      * @return string The name.
      */
-    public function getName( bool $short = false ): string
+    public function getName(bool $short = false): string
     {
         $name = $this->name;
 
-        if( $short ) {
-            $name = substr( $this->name, 0, -( strlen( $this->zone->getCanonicalName() ) + 1 ) );
+        if ($short) {
+            $name = substr($this->name, 0, -(strlen($this->zone->getCanonicalName()) + 1));
 
-            if( strlen( $name ) == 0 )
-                $name = "@";
+            if (strlen($name) == 0) {
+                $name = '@';
+            }
         }
 
         return $name;
     }
-    
+
     /**
      * Set the name of the resource record.
      *

--- a/tests/Resources/ResourceRecordTest.php
+++ b/tests/Resources/ResourceRecordTest.php
@@ -35,8 +35,8 @@ class ResourceRecordTest extends TestCase
                 'ttl' => 3600,
                 'changetype' => 'REPLACE',
                 'records' => [
-                    ['content' => '127.0.0.1', 'disabled' => false]
-                ]
+                    ['content' => '127.0.0.1', 'disabled' => false],
+                ],
             ];
 
         $resourceRecord = (new ResourceRecord())->setApiResponse($apiResponse);
@@ -54,11 +54,11 @@ class ResourceRecordTest extends TestCase
                 ],
             ]
         )->once()->andReturnTrue();
-        $zone->allows()->getCanonicalName()->andReturns("test.nl.");
+        $zone->allows()->getCanonicalName()->andReturns('test.nl.');
 
         $resourceRecord = $resourceRecord->setZone($zone);
 
-        $this->assertSame($resourceRecord->getName( true ), "record");
+        $this->assertSame($resourceRecord->getName(true), 'record');
 
         $this->assertTrue($resourceRecord->save());
         $this->assertTrue($resourceRecord->delete());
@@ -70,7 +70,7 @@ class ResourceRecordTest extends TestCase
                 'ttl' => 3600,
                 'changetype' => 'REPLACE',
                 'records' => [
-                    ['content' => '127.0.0.1', 'disabled' => false]
+                    ['content' => '127.0.0.1', 'disabled' => false],
                 ],
                 'comments' => [
                     ['content' => 'Test comment', 'account' => 'Test account', 'modified_at' => 1234],
@@ -78,9 +78,9 @@ class ResourceRecordTest extends TestCase
             ];
 
         $resourceRecord = (new ResourceRecord())->setApiResponse($apiResponse);
-        $resourceRecord->setZone( $zone );
+        $resourceRecord->setZone($zone);
 
-        $this->assertSame($resourceRecord->getName( true ), "@");
+        $this->assertSame($resourceRecord->getName(true), '@');
     }
 
     public function testSetApiResponse(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The getName method of the ResourceRecord class returns the name without the domainname ( @ when empty ) of the record name when $short parameter is true. Default is false.

## Motivation and context

This feature is very handy for display the name on webpage's like DNS editor's in controle panels.

## How has this been tested?

We are developing a control panel and this feature is tested in this new control panel. Also added tests.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
