### PR TITLE
#109 Make package compatible with psr/log 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "^7.3|^8.0",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.2",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0|^2.0|^3.0"
   },
   "require-dev": {
     "dms/phpunit-arraysubset-asserts": "^0.2.1 || ^0.4.0",


### PR DESCRIPTION
## Description

Add additional `psr/log` versions to composer so the library is compabible with projects using newer `psr/log` version. Details as in https://github.com/exonet/powerdns-php/issues/109

## Motivation and context

It's impossible to use the library in projects with `psr/log` other than `^1.0`. That excludes almost all modern projects with `psr/log` 3.0.

## How has this been tested?

The existing tests pass.

Changes between `psr/log` major versions 1.0, 2.0 and 3.0 don't change the public interface but only add type hints according to minimal PHP versions for `psr/log` . The `powerdns-php` is using logger interface properly, so it doesn't require any code updates.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
