### PR TITLE
Added getShortName() method

### DIFF
--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -6,6 +6,7 @@ namespace Exonet\Powerdns\Resources;
 
 use Exonet\Powerdns\Exceptions\InvalidChangeType;
 use Exonet\Powerdns\Exceptions\InvalidRecordType;
+use Exonet\Powerdns\Exceptions\PowerdnsException;
 use Exonet\Powerdns\RecordType;
 use Exonet\Powerdns\Zone;
 use ReflectionClass;
@@ -238,6 +239,28 @@ class ResourceRecord
         return $this->name;
     }
 
+    /**
+     * Get the name of the resource record without the domain name.
+     * "@" when empty.
+     *
+     * @return string The short name
+     *
+     * @throws PowerdnsException
+     */
+    public function getShortName(): string
+    {
+        if( $this->zone !== null ) {
+            $name = substr( $this->name, 0, -( strlen( $this->zone->getCanonicalName() ) + 1 ) );
+
+            if( strlen( $name ) == 0 )
+                $name = "@";
+        } else {
+            throw new PowerdnsException("No zone set for this ResourceRecord. Unable to shorten name");
+        }
+
+        return $name;
+    }
+    
     /**
      * Set the name of the resource record.
      *


### PR DESCRIPTION
Get only the subdomain from the ResourceRecord object.

## Description

Get only the subdomain part from the ResourceRecord object

## Motivation and context

This method creates an easy way to get only the subdomain part from the ResourceRecord. Handy in situations where the domain part is obvious or unnecessary.

## How has this been tested?

Tested by using it in our project.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
