### PR TITLE
added basic auth support for PowerDNS API when hosted behind reverse …

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -30,13 +30,27 @@ class Connector implements ConnectorInterface
      *
      * @param Powerdns|null     $client             The client instance.
      * @param HandlerStack|null $guzzleHandlerStack Optional Guzzle handlers.
+     * @param string|null       $basicAuthUsername  Optional username if PowerDNS api is behind reverse proxy with basic auth
+     * @param string|null       $basicAuthPassword  Optional password if PowerDNS api is behind reverse proxy with basic auth
      */
-    public function __construct(Powerdns $client, ?HandlerStack $guzzleHandlerStack = null)
+    public function __construct(
+        Powerdns $client,
+        ?HandlerStack $guzzleHandlerStack = null,
+        ?string $basicAuthUsername = null,
+        ?string $basicAuthPassword = null)
     {
         $this->powerdns = $client;
 
         // Don't let Guzzle throw exceptions, as it is handled by this class.
-        $this->httpClient = new GuzzleClient(['exceptions' => false, 'handler' => $guzzleHandlerStack]);
+        $options = ['exceptions' => false, 'handler' => $guzzleHandlerStack];
+
+        if (isset($basicAuthUsername) && isset($basicAuthPassword)) {
+            $options['headers'] = [
+                'Authorization' => 'Basic ' . base64_encode($basicAuthUsername . ':' . $basicAuthPassword)
+            ];
+        }
+
+        $this->httpClient = new GuzzleClient($options);
     }
 
     /**

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -55,18 +55,22 @@ class Powerdns implements PowerdnsInterface
     /**
      * PowerDNS Client constructor.
      *
-     * @param string|null             $host      (optional) The PowerDNS host. Must include protocol (http, https, etc.).
-     * @param string|null             $apiKey    (optional) The PowerDNS API key.
-     * @param int|null                $port      (optional) The PowerDNS API Port.
-     * @param string|null             $server    (optional) The PowerDNS server to use.
-     * @param ConnectorInterface|null $connector (optional) The Connector to make calls.
+     * @param string|null             $host              (optional) The PowerDNS host. Must include protocol (http, https, etc.).
+     * @param string|null             $apiKey            (optional) The PowerDNS API key.
+     * @param int|null                $port              (optional) The PowerDNS API Port.
+     * @param string|null             $server            (optional) The PowerDNS server to use.
+     * @param ConnectorInterface|null $connector         (optional) The Connector to make calls.
+     * @param string|null             $basicAuthUsername (optional) Username for Basic Authentication behind Reverse Proxies
+     * @param string|null             $basicAuthPassword (optional) Username for Basic Authentication behind Reverse Proxies
      */
     public function __construct(
         ?string $host = null,
         ?string $apiKey = null,
         ?int $port = null,
         ?string $server = null,
-        ?ConnectorInterface $connector = null
+        ?ConnectorInterface $connector = null,
+        ?string $basicAuthUsername = null,
+        ?string $basicAuthPassword = null
     ) {
         if (self::$_instance === null) {
             self::$_instance = $this;
@@ -88,7 +92,7 @@ class Powerdns implements PowerdnsInterface
             $this->server = $server;
         }
 
-        $this->connector = $connector ?? new Connector($this);
+        $this->connector = $connector ?? new Connector($this, null, $basicAuthUsername, $basicAuthPassword);
     }
 
     /**


### PR DESCRIPTION
It is possible to host the PowerDNS API behind a reverse proxy (like Nginx) and enforce basic authentication in addition to the use of the API key for additional security. This pull request adds the possibility to define a username and a password to match the basic authentication header needs.