### PR TITLE
Change the kind of zone

### DIFF
--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -15,7 +15,7 @@ class Powerdns implements PowerdnsInterface
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = '';
+    public const CLIENT_VERSION = 'v4.2.1';
 
     /**
      * @var Powerdns The client instance.

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -15,7 +15,7 @@ class Powerdns implements PowerdnsInterface
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v4.2.1';
+    public const CLIENT_VERSION = '';
 
     /**
      * @var Powerdns The client instance.

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -314,7 +314,7 @@ class Zone
      */
     public function setMasters(array $masters): self
     {
-        if ($this->kind !== 'Slave') {
+        if ($this->kind !== 'Slave' && $masters !== []) {
             throw new InvalidKindType(sprintf('Only "Slave" kind zones can set masters, not "%s".', $this->kind));
         }
 

--- a/src/Transformers/KindTransformer.php
+++ b/src/Transformers/KindTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class KindTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        $result = (object) [
+            'kind' => $this->data['kind'],
+        ];
+        if ('Slave' == $this->data['kind']) {
+            $result->masters = $this->data['masters'];
+        }
+        return $result;
+    }
+}

--- a/src/Transformers/KindTransformer.php
+++ b/src/Transformers/KindTransformer.php
@@ -12,7 +12,7 @@ class KindTransformer extends Transformer
         $result = (object) [
             'kind' => $this->data['kind'],
         ];
-        if ('Slave' == $this->data['kind']) {
+        if ('Slave' === $this->data['kind']) {
             $result->masters = $this->data['masters'];
         }
 

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -280,7 +280,7 @@ class Zone extends AbstractZone
      * Set the kind of zone: Native, Master or Slave
      *
      * @param string $kind Native, Master or Slave
-     * @param array<string> $masters In case of kind=Slave: Master IPs.
+     * @param array<string> $masters In case of Slave kind: Master IPs.
      *
      * @return bool True when the request succeeded.
      */

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -7,6 +7,7 @@ use Exonet\Powerdns\Resources\Record;
 use Exonet\Powerdns\Resources\ResourceRecord;
 use Exonet\Powerdns\Resources\ResourceSet;
 use Exonet\Powerdns\Transformers\DnssecTransformer;
+use Exonet\Powerdns\Transformers\KindTransformer;
 use Exonet\Powerdns\Transformers\Nsec3paramTransformer;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
 use Exonet\Powerdns\Transformers\SoaEditApiTransformer;
@@ -273,5 +274,20 @@ class Zone extends AbstractZone
     public function setSoaEditApi(string $value): bool
     {
         return $this->put(new SoaEditApiTransformer(['soa_edit_api' => $value]));
+    }
+
+    /**
+     * Set the kind of zone: Native, Master or Slave
+     *
+     * @param string $kind Native, Master or Slave
+     * @param array<string> $masters In case of kind=Slave: Master IPs.
+     *
+     * @return bool True when the request succeeded.
+     */
+    public function setKind(string $kind, array $masters=[]): bool
+    {
+        $this->resource()->setKind($kind);
+        $this->resource()->setMasters($masters);
+        return $this->put(new KindTransformer(['kind' => $kind, 'masters' => $masters]));
     }
 }

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -231,4 +231,20 @@ class ZoneTest extends TestCase
         $zone = new Zone($connector, 'test.nl');
         $this->assertTrue($zone->notify());
     }
+
+    public function testSetKind(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('put')->withArgs(['zones/test.nl.', Mockery::on(function ($transformer) {
+            $transformed = $transformer->transform();
+            $this->assertSame('Slave', $transformed->kind);
+            $this->assertSame(['1.1.1.1'], $transformed->masters);
+
+            return true;
+        })])->once()->andReturn([]);
+        $zone = Mockery::mock(Zone::class.'[resource]', [$connector, 'test.nl'])->makePartial();
+        $zone->shouldReceive('resource')->withNoArgs()->once()->andReturn(new ZoneResource());
+
+        $zone->setKind('Slave', ['1.1.1.1']);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To automate moving zones to PowerDNS we make them Slave first and later change them to Master.

## Motivation and context

This library could not do that yet, so I have implemented it.

## How has this been tested?

- Added unit test
- All Github Actions are green.
- Changed Master->Slave and Slave->Master on live PowerDNS 4.7.3

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
