### PR TITLE
Added record type TYPE65534.

### DIFF
--- a/src/RecordType.php
+++ b/src/RecordType.php
@@ -294,6 +294,13 @@ class RecordType
     public const TXT = 'TXT';
 
     /**
+     * Private Bind record.
+     *
+     * These records are used by BIND to record some dynamic signing state.
+     */
+    public const TYPE65534 = 'TYPE65534';
+
+    /**
      * Uniform Resource Identifier.
      *
      * Can be used for publishing mappings from hostnames to URIs.


### PR DESCRIPTION
## Description

The record type TYPE65534 appears in PowerDNS in some zones we are slave for.

## Motivation and context

Without this change Exonet PowerDNS throws exception:
```
PHP Fatal error:  Uncaught Exonet\Powerdns\Exceptions\InvalidRecordType: The record type [TYPE65534] is not a valid DNS Record type. in .../vendor/exonet/powerdns-php/src/Resources/ResourceRecord.php:387
```

## How has this been tested?

Loading 37362 zones from a PowerDNS 4.7.4 cluster.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. => There is currently not a separate tests for each record type.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
