### PR TITLE
Add support for private record types

### DIFF
--- a/src/RecordType.php
+++ b/src/RecordType.php
@@ -299,4 +299,22 @@ class RecordType
      * Can be used for publishing mappings from hostnames to URIs.
      */
     public const URI = 'URI';
+
+    /**
+     * Prefix for "Unknown" type records. Private resource records fall under this category.
+     * https://datatracker.ietf.org/doc/html/rfc3597#section-5
+     */
+    public const unknownTypePrefix = 'TYPE';
+
+    /**
+     * Minimal type number for a Private resource record.
+     * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+     */
+    public const privateTypeMin = 65280;
+
+    /**
+     * Maximum type number for a Private resource record.
+     * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+     */
+    public const privateTypeMax = 65534;
 }

--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -384,6 +384,16 @@ class ResourceRecord
             return $this;
         }
 
+        $unknownTypeRegex = '/^' . preg_quote(RecordType::unknownTypePrefix, '/') . '(\d+)$/';
+        if (preg_match($unknownTypeRegex, $type, $matches)) {
+            if (is_numeric($matches[1]) &&
+                intval($matches[1]) >= RecordType::privateTypeMin &&
+                intval($matches[1]) <= RecordType::privateTypeMax) {
+                $this->type = $type;
+                return $this;
+            }
+        }
+
         throw new InvalidRecordType(sprintf('The record type [%s] is not a valid DNS Record type.', $type));
     }
 

--- a/tests/Resources/ResourceRecordTest.php
+++ b/tests/Resources/ResourceRecordTest.php
@@ -128,4 +128,16 @@ class ResourceRecordTest extends TestCase
         $this->expectExceptionMessage('No zone set for this ResourceRecord. Unable to shorten name');
         (new ResourceRecord())->getShortName();
     }
+
+    public function testPrivateType()
+    {
+        $resourceRecord = new ResourceRecord();
+        $resourceRecord->setType('TYPE65534');
+        $this->assertSame('TYPE65534', $resourceRecord->getType());
+
+        $resourceRecord = new ResourceRecord();
+        $this->expectException(InvalidRecordType::class);
+        $this->expectExceptionMessage('The record type [TYPE1] is not a valid DNS Record type.');
+        $resourceRecord->setType('TYPE1');
+    }
 }

--- a/tests/functional/ZoneRecordsTest.php
+++ b/tests/functional/ZoneRecordsTest.php
@@ -21,6 +21,7 @@ class ZoneRecordsTest extends FunctionalTestCase
         ['name' => 'www', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
         ['name' => 'www', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60],
         ['name' => 'bla', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+        ['name' => '@', 'type' => RecordType::unknownTypePrefix . 65534, 'content' => '\# 4 aabbccdd', 'ttl' => 60],
         ['name' => '@', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
         [
             'name' => '@',


### PR DESCRIPTION
Added support for private record types, TYPE65280 till TYPE65534

## Description

See issue #135

## Motivation and context

See issue #135

## How has this been tested?

The test included in issue #135 + loading 44296 other zones from our PowerDNS 4.7.4 cluster.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
