### PR TITLE
fix: RRSet save comments

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -16,7 +16,7 @@ class Helper
      * @param string       $type     The type of the resource record.
      * @param array|string $content  The content of the resource record.
      * @param int          $ttl      The TTL.
-     * @param array       $comments The Comment.
+     * @param array        $comments The Comment.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *
@@ -51,7 +51,7 @@ class Helper
             ->setName($name)
             ->setType($type)
             ->setTtl($ttl);
-       
+
         if (is_string($content)) {
             $content = [$content];
         }

--- a/src/Transformers/CommentTransformer.php
+++ b/src/Transformers/CommentTransformer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class CommentTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        return (object) [
+            'content' => $this->data->getContent(),
+            'account' => $this->data->getAccount(),
+            'modified_at' => $this->data->getModifiedAt(),
+        ];
+    }
+}

--- a/src/Transformers/RRSetTransformer.php
+++ b/src/Transformers/RRSetTransformer.php
@@ -41,6 +41,9 @@ class RRSetTransformer extends Transformer
             'ttl' => $resourceRecord->getTtl(),
             'changetype' => $resourceRecord->getChangeType(),
             'records' => $recordList,
+            'comments' => array_map(function($comment) {
+                return (new CommentTransformer($comment))->transform();
+            } ,$resourceRecord->getComments())
         ];
     }
 

--- a/src/Transformers/RRSetTransformer.php
+++ b/src/Transformers/RRSetTransformer.php
@@ -41,9 +41,9 @@ class RRSetTransformer extends Transformer
             'ttl' => $resourceRecord->getTtl(),
             'changetype' => $resourceRecord->getChangeType(),
             'records' => $recordList,
-            'comments' => array_map(function($comment) {
+            'comments' => array_map(function ($comment) {
                 return (new CommentTransformer($comment))->transform();
-            } ,$resourceRecord->getComments())
+            }, $resourceRecord->getComments()),
         ];
     }
 

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -25,8 +25,8 @@ class Zone extends AbstractZone
      * @param string         $type     The type of the resource record.
      * @param mixed[]|string $content  The content of the resource record. When passing a multidimensional array,
      *                                 multiple records are created for this resource record.
-     * @param array|mixed[]  $comments The comment to assign to the record.
      * @param int            $ttl      The TTL.
+     * @param array|mixed[]  $comments The comment to assign to the record.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -21,25 +21,26 @@ class Zone extends AbstractZone
      * resource records will be created in a single call to the PowerDNS server. If $name is a string, a single resource
      * record is created.
      *
-     * @param mixed[]|string $name    The resource record name.
-     * @param string         $type    The type of the resource record.
-     * @param mixed[]|string $content The content of the resource record. When passing a multidimensional array,
-     *                                multiple records are created for this resource record.
-     * @param int            $ttl     The TTL.
+     * @param mixed[]|string $name     The resource record name.
+     * @param string         $type     The type of the resource record.
+     * @param mixed[]|string $content  The content of the resource record. When passing a multidimensional array,
+     *                                 multiple records are created for this resource record.
+     * @param mixed[]|array $comments The comment to assign to the record.
+     * @param int            $ttl      The TTL.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *
      * @return bool True when created.
      */
-    public function create($name, string $type = '', $content = '', int $ttl = 3600): bool
+    public function create($name, string $type = '', $content = '', int $ttl = 3600, array $comments = []): bool
     {
         if (is_array($name)) {
             $resourceRecords = [];
             foreach ($name as $item) {
-                $resourceRecords[] = $this->make($item['name'], $item['type'], $item['content'], $item['ttl'] ?? $ttl);
+                $resourceRecords[] = $this->make($item['name'], $item['type'], $item['content'], $item['ttl'] ?? $ttl, $item['comments'] ?? []);
             }
         } else {
-            $resourceRecords = [$this->make($name, $type, $content, $ttl)];
+            $resourceRecords = [$this->make($name, $type, $content, $ttl, $comments)];
         }
 
         return $this->patch($resourceRecords);
@@ -138,18 +139,19 @@ class Zone extends AbstractZone
     /**
      * Make (but not insert/POST) a new resource record.
      *
-     * @param string $name    The resource record name.
-     * @param string $type    The type of the resource record.
-     * @param string $content The content of the resource record.
-     * @param int    $ttl     The TTL.
+     * @param string $name     The resource record name.
+     * @param string $type     The type of the resource record.
+     * @param string $content  The content of the resource record.
+     * @param int    $ttl      The TTL.
+     * @param array  $comments The Comments.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *
      * @return ResourceRecord The constructed ResourceRecord.
      */
-    public function make(string $name, string $type, $content, int $ttl): ResourceRecord
+    public function make(string $name, string $type, $content, int $ttl, array $comments): ResourceRecord
     {
-        return Helper::createResourceRecord($this->zone, compact('name', 'type', 'content', 'ttl'));
+        return Helper::createResourceRecord($this->zone, compact('name', 'type', 'content', 'ttl', 'comments'));
     }
 
     /**

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -25,7 +25,7 @@ class Zone extends AbstractZone
      * @param string         $type     The type of the resource record.
      * @param mixed[]|string $content  The content of the resource record. When passing a multidimensional array,
      *                                 multiple records are created for this resource record.
-     * @param mixed[]|array $comments The comment to assign to the record.
+     * @param array|mixed[]  $comments The comment to assign to the record.
      * @param int            $ttl      The TTL.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -21,6 +21,7 @@ class HelperTest extends TestCase
         self::assertCount(1, $result->getRecords());
         self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
         self::assertSame('Hello World', $result->getComments()[0]->getContent());
+        self::assertSame('Tester', $result->getComments()[0]->getAccount());
     }
 
     public function testWithArray(): void
@@ -34,16 +35,16 @@ class HelperTest extends TestCase
                 'ttl' => 1337,
                 'comments' => [
                     [
-                        'content' => "Hello",
+                        'content' => 'Hello',
                         'account' => 'rooti',
-                        'modified_at' => 999
+                        'modified_at' => 999,
                     ],
                     [
-                        'content' => "World",
+                        'content' => 'World',
                         'account' => 'rooti',
-                        'modified_at' => 111
-                    ]
-                ]
+                        'modified_at' => 111,
+                    ],
+                ],
             ]
         );
 
@@ -54,6 +55,8 @@ class HelperTest extends TestCase
         self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
         self::assertSame('127.0.0.2', $result->getRecords()[1]->getContent());
         self::assertSame(111, $result->getComments()[1]->getModifiedAt());
+        self::assertSame('World', $result->getComments()[1]->getContent());
+        self::assertSame('rooti', $result->getComments()[1]->getAccount());
     }
 
     public function testWithApiResponse(): void

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -13,13 +13,14 @@ class HelperTest extends TestCase
 {
     public function testWithArguments(): void
     {
-        $result = Helper::createResourceRecord('unit.test.', 'www', RecordType::A, '127.0.0.1', 1337);
+        $result = Helper::createResourceRecord('unit.test.', 'www', RecordType::A, '127.0.0.1', 1337, [['content' => 'Hello World', 'account' => 'Tester']]);
 
         self::assertSame('www.unit.test.', $result->getName());
         self::assertSame('A', $result->getType());
         self::assertSame(1337, $result->getTtl());
         self::assertCount(1, $result->getRecords());
         self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
+        self::assertSame('Hello World', $result->getComments()[0]->getContent());
     }
 
     public function testWithArray(): void
@@ -31,6 +32,18 @@ class HelperTest extends TestCase
                 'type' => RecordType::A,
                 'content' => ['127.0.0.1', '127.0.0.2'],
                 'ttl' => 1337,
+                'comments' => [
+                    [
+                        'content' => "Hello",
+                        'account' => 'rooti',
+                        'modified_at' => 999
+                    ],
+                    [
+                        'content' => "World",
+                        'account' => 'rooti',
+                        'modified_at' => 111
+                    ]
+                ]
             ]
         );
 
@@ -40,6 +53,7 @@ class HelperTest extends TestCase
         self::assertCount(2, $result->getRecords());
         self::assertSame('127.0.0.1', $result->getRecords()[0]->getContent());
         self::assertSame('127.0.0.2', $result->getRecords()[1]->getContent());
+        self::assertSame(111, $result->getComments()[1]->getModifiedAt());
     }
 
     public function testWithApiResponse(): void

--- a/tests/Resources/CommentTest.php
+++ b/tests/Resources/CommentTest.php
@@ -3,6 +3,7 @@
 namespace Exonet\Powerdns\tests\Resources;
 
 use Exonet\Powerdns\Resources\Comment;
+use Exonet\Powerdns\Transformers\CommentTransformer;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,5 +23,21 @@ class CommentTest extends TestCase
         $this->assertSame('test account', $comment->getAccount());
         $this->assertSame('test content', $comment->getContent());
         $this->assertSame(1234, $comment->getModifiedAt());
+    }
+
+    public function testTransformer(): void
+    {
+        $comment = (new Comment())
+            ->setAccount('test account')
+            ->setContent('test content')
+            ->setModifiedAt(1234);
+
+        $transformer = new CommentTransformer($comment);
+
+        $this->assertEquals((object) [
+            'modified_at' => 1234,
+            'account' => 'test account',
+            'content' => 'test content'
+        ], $transformer->transform());
     }
 }

--- a/tests/Resources/CommentTest.php
+++ b/tests/Resources/CommentTest.php
@@ -37,7 +37,7 @@ class CommentTest extends TestCase
         $this->assertEquals((object) [
             'modified_at' => 1234,
             'account' => 'test account',
-            'content' => 'test content'
+            'content' => 'test content',
         ], $transformer->transform());
     }
 }

--- a/tests/functional/ZoneRecordsTest.php
+++ b/tests/functional/ZoneRecordsTest.php
@@ -27,7 +27,7 @@ class ZoneRecordsTest extends FunctionalTestCase
             'name' => '@',
             'type' => RecordType::SOA,
             'content' => 'ns1.test. hostmaster.test. 0 10800 3605 604800 3600',
-            'ttl' => 60, 
+            'ttl' => 60,
             'comments' => [],
         ],
         ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns1.powerdns-php.', 'ttl' => 60, 'comments' => []],
@@ -90,7 +90,7 @@ class ZoneRecordsTest extends FunctionalTestCase
                         'type' => $item->getType(),
                         'content' => $content,
                         'ttl' => $item->getTtl(),
-                        'comments' => []
+                        'comments' => [],
                     ];
                 }
             }

--- a/tests/functional/ZoneRecordsTest.php
+++ b/tests/functional/ZoneRecordsTest.php
@@ -18,20 +18,21 @@ class ZoneRecordsTest extends FunctionalTestCase
     private $canonicalName;
 
     private $dnsRecords = [
-        ['name' => 'www', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
-        ['name' => 'www', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60],
-        ['name' => 'bla', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
-        ['name' => '@', 'type' => RecordType::unknownTypePrefix. 65534, 'content' => '\# 4 aabbccdd', 'ttl' => 60],
-        ['name' => '@', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60],
+        ['name' => 'www', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60, 'comments' => []],
+        ['name' => 'www', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60, 'comments' => []],
+        ['name' => 'bla', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60, 'comments' => []],
+        ['name' => '@', 'type' => RecordType::unknownTypePrefix. 65534, 'content' => '\# 4 aabbccdd', 'ttl' => 60, 'comments' => []],
+        ['name' => '@', 'type' => RecordType::AAAA, 'content' => '2a00:1e28:3:1629::1', 'ttl' => 60, 'comments' => []],
         [
             'name' => '@',
             'type' => RecordType::SOA,
             'content' => 'ns1.test. hostmaster.test. 0 10800 3605 604800 3600',
-            'ttl' => 60,
+            'ttl' => 60, 
+            'comments' => [],
         ],
-        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns1.powerdns-php.', 'ttl' => 60],
-        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns2.powerdns-php.', 'ttl' => 60],
-        ['name' => '@', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60],
+        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns1.powerdns-php.', 'ttl' => 60, 'comments' => []],
+        ['name' => '@', 'type' => RecordType::NS, 'content' => 'ns2.powerdns-php.', 'ttl' => 60, 'comments' => []],
+        ['name' => '@', 'type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60, 'comments' => []],
     ];
 
     protected function setUp(): void
@@ -89,6 +90,7 @@ class ZoneRecordsTest extends FunctionalTestCase
                         'type' => $item->getType(),
                         'content' => $content,
                         'ttl' => $item->getTtl(),
+                        'comments' => []
                     ];
                 }
             }


### PR DESCRIPTION
## Description

Hello, while testing i realized that the code-side of updating/adding comments is there, just missing in the transformers for the actual request. This PR adds the functionality and should work as expected.

Relevant docs: https://doc.powerdns.com/authoritative/http-api/zone.html#rrset

## Motivation and context

Well

## How has this been tested?

./run-test script runs through no problem, changing my local development env to my github repo and adding/updating comments updates them accordingly

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
