### PR TITLE
Support passing `ResourceRecord` objects when creating new records

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Basic example how to create a new DNS zone and insert a few DNS records.
 ```php
 use Exonet\Powerdns\Powerdns;
 use Exonet\Powerdns\RecordType;
+use Exonet\Powerdns\Resources\ResourceRecord;
+use Exonet\Powerdns\Resources\Record;
 
 // Initialize the Powerdns client.
 $powerdns = new Powerdns('127.0.0.1', 'powerdns_secret_string');
@@ -32,6 +34,12 @@ $zone = $powerdns->createZone(
 $zone->create([
     ['type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60, 'name' => '@'],
     ['type' => RecordType::A, 'content' => '127.0.0.1', 'ttl' => 60, 'name' => 'www'],
+]);
+
+// OR use the Object-based way
+$zone->create([
+    (new ResourceRecord())->setType(RecordType::A)->setRecord('127.0.0.1')->setName('@')->setTtl(60),
+    (new ResourceRecord())->setType(RecordType::A)->setRecord((new Record())->setContent('127.0.0.1'))->setName('@')->setTtl(60),
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ $zone->create([
 
 // OR use the Object-based way
 $zone->create([
-    (new ResourceRecord())->setType(RecordType::A)->setRecord('127.0.0.1')->setName('@')->setTtl(60),
-    (new ResourceRecord())->setType(RecordType::A)->setRecord((new Record())->setContent('127.0.0.1'))->setName('@')->setTtl(60),
+    (new ResourceRecord())->setZone($zone)->setType(RecordType::A)->setRecord('127.0.0.1')->setName('@')->setTtl(60),
+    (new ResourceRecord())->setZone($zone)->setType(RecordType::A)->setRecord((new Record())->setContent('127.0.0.1'))->setName('@')->setTtl(60),
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ $zone->create([
 
 // OR use the Object-based way
 $zone->create([
-    (new ResourceRecord())->setZone($zone)->setType(RecordType::A)->setRecord('127.0.0.1')->setName('@')->setTtl(60),
-    (new ResourceRecord())->setZone($zone)->setType(RecordType::A)->setRecord((new Record())->setContent('127.0.0.1'))->setName('@')->setTtl(60),
+    (new ResourceRecord())->setType(RecordType::A)->setRecord('127.0.0.1')->setName('@')->setTtl(60),
+    (new ResourceRecord())->setType(RecordType::A)->setRecord((new Record())->setContent('127.0.0.1'))->setName('@')->setTtl(60),
 ]);
 ```
 

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -15,7 +15,7 @@ class Powerdns implements PowerdnsInterface
     /**
      * The version of this package. This is being used for the user-agent header.
      */
-    public const CLIENT_VERSION = 'v4.4.1';
+    public const CLIENT_VERSION = 'v4.5.0';
 
     /**
      * @var Powerdns The client instance.

--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -271,6 +271,15 @@ class ResourceRecord
      */
     public function setName(string $name): self
     {
+        if ($this->getZone() !== null) {
+            $name = str_replace('@', $this->getZone()->getCanonicalName(), $name);
+
+            // If the name of the record doesn't end in the zone name, append the zone name to it.
+            if (substr($name, -strlen($this->getZone()->getCanonicalName())) !== $this->getZone()->getCanonicalName()) {
+                $name = sprintf('%s.%s', $name, $this->getZone()->getCanonicalName());
+            }
+        }
+
         $this->name = $name;
 
         return $this;
@@ -398,9 +407,9 @@ class ResourceRecord
     /**
      * Get the zone object for this ResourceRecord.
      *
-     * @return Zone The zone for this ResourceRecord.
+     * @return Zone|null The zone for this ResourceRecord.
      */
-    public function getZone(): Zone
+    public function getZone(): ?Zone
     {
         return $this->zone;
     }

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -13,7 +13,8 @@ use Exonet\Powerdns\Transformers\SoaEditApiTransformer;
 use Exonet\Powerdns\Transformers\SoaEditTransformer;
 use Exonet\Powerdns\Transformers\Transformer;
 
-class Zone extends AbstractZone {
+class Zone extends AbstractZone
+{
     /**
      * Create one or more new resource records in the current zone. If $name is passed as multidimensional array those
      * resource records will be created in a single call to the PowerDNS server. If $name is a string, a single resource
@@ -30,7 +31,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when created.
      */
-    public function create($name, string $type = '', $content = '', int $ttl = 3600, array $comments = []): bool {
+    public function create($name, string $type = '', $content = '', int $ttl = 3600, array $comments = []): bool
+    {
         if (is_array($name)) {
             $resourceRecords = [];
             foreach ($name as $item) {
@@ -60,7 +62,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when successful.
      */
-    public function patch(array $resourceRecords): bool {
+    public function patch(array $resourceRecords): bool
+    {
         $result = $this->connector->patch($this->getZonePath(), new RRSetTransformer($resourceRecords));
         // Invalidate the resource.
         $this->zoneResource = null;
@@ -79,7 +82,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when successful.
      */
-    public function put(Transformer $transformer): bool {
+    public function put(Transformer $transformer): bool
+    {
         $result = $this->connector->put($this->getZonePath(), $transformer);
         // Invalidate the resource.
         $this->zoneResource = null;
@@ -99,7 +103,8 @@ class Zone extends AbstractZone {
      *
      * @return ResourceSet A ResourceSet containing all the resource records.
      */
-    public function get(?string $recordType = null): ResourceSet {
+    public function get(?string $recordType = null): ResourceSet
+    {
         $resourceSet = new ResourceSet($this);
 
         foreach ($this->resource()->getResourceRecords() as $rrset) {
@@ -120,16 +125,17 @@ class Zone extends AbstractZone {
      *
      * @return ResourceSet A ResourceSet containing all the resource records.
      */
-    public function find(string $resourceRecordName, ?string $recordType = null): ResourceSet {
+    public function find(string $resourceRecordName, ?string $recordType = null): ResourceSet
+    {
         $resourceRecordName = $resourceRecordName === '@' ? $this->zone : $resourceRecordName;
-        $records            = $this->get($recordType);
+        $records = $this->get($recordType);
 
         $foundResources = new ResourceSet($this);
 
         foreach ($records as $record) {
             if (
                 $record->getName() === $resourceRecordName
-                || $record->getName() === $resourceRecordName . '.'
+                || $record->getName() === $resourceRecordName.'.'
                 || $record->getName() === sprintf('%s.%s', $resourceRecordName, $this->zone)
             ) {
                 $foundResources->addResource($record);
@@ -152,7 +158,8 @@ class Zone extends AbstractZone {
      *
      * @return ResourceRecord The constructed ResourceRecord.
      */
-    public function make(string $name, string $type, $content, int $ttl, array $comments): ResourceRecord {
+    public function make(string $name, string $type, $content, int $ttl, array $comments): ResourceRecord
+    {
         return Helper::createResourceRecord($this->zone, compact('name', 'type', 'content', 'ttl', 'comments'));
     }
 
@@ -161,7 +168,8 @@ class Zone extends AbstractZone {
      *
      * @return string The zone in AXFR format.
      */
-    public function export(): string {
+    public function export(): string
+    {
         $result = $this->connector->get($this->getZonePath('/export'));
 
         return $result['zone'];
@@ -179,8 +187,9 @@ class Zone extends AbstractZone {
      *
      * @return bool True when updated.
      */
-    public function setNsec3param(?string $nsec3param): bool {
-        $zone        = $this->resource()->setNsec3param($nsec3param);
+    public function setNsec3param(?string $nsec3param): bool
+    {
+        $zone = $this->resource()->setNsec3param($nsec3param);
         $transformer = new Nsec3paramTransformer($zone);
 
         return $this->put($transformer);
@@ -193,7 +202,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when updated.
      */
-    public function unsetNsec3param(): bool {
+    public function unsetNsec3param(): bool
+    {
         return $this->setNsec3param(null);
     }
 
@@ -202,7 +212,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when the DNS notify was successfully sent
      */
-    public function notify(): bool {
+    public function notify(): bool
+    {
         $result = $this->connector->put($this->getZonePath('/notify'));
 
         /*
@@ -217,7 +228,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when enabled.
      */
-    public function enableDnssec(): bool {
+    public function enableDnssec(): bool
+    {
         return $this->setDnssec(true);
     }
 
@@ -226,7 +238,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when disabled.
      */
-    public function disableDnssec(): bool {
+    public function disableDnssec(): bool
+    {
         return $this->setDnssec(false);
     }
 
@@ -237,7 +250,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when the request succeeded.
      */
-    public function setDnssec(bool $state): bool {
+    public function setDnssec(bool $state): bool
+    {
         return $this->put(new DnssecTransformer(['dnssec' => $state]));
     }
 
@@ -246,7 +260,8 @@ class Zone extends AbstractZone {
      *
      * @return Cryptokey The DNSSEC instance.
      */
-    public function dnssec(): Cryptokey {
+    public function dnssec(): Cryptokey
+    {
         return new Cryptokey($this->connector, $this->zone);
     }
 
@@ -255,7 +270,8 @@ class Zone extends AbstractZone {
      *
      * @return Meta The meta data.
      */
-    public function meta(): Meta {
+    public function meta(): Meta
+    {
         return new Meta($this->connector, $this->zone);
     }
 
@@ -266,7 +282,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when the request succeeded.
      */
-    public function setSoaEdit(string $value): bool {
+    public function setSoaEdit(string $value): bool
+    {
         return $this->put(new SoaEditTransformer(['soa_edit' => $value]));
     }
 
@@ -277,7 +294,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when the request succeeded.
      */
-    public function setSoaEditApi(string $value): bool {
+    public function setSoaEditApi(string $value): bool
+    {
         return $this->put(new SoaEditApiTransformer(['soa_edit_api' => $value]));
     }
 
@@ -289,7 +307,8 @@ class Zone extends AbstractZone {
      *
      * @return bool True when the request succeeded.
      */
-    public function setKind(string $kind, array $masters = []): bool {
+    public function setKind(string $kind, array $masters = []): bool
+    {
         $this->resource()->setKind($kind);
         $this->resource()->setMasters($masters);
 

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -20,11 +20,11 @@ class Zone extends AbstractZone {
      * record is created.
      *
      * @param mixed[]|ResourceRecord|ResourceRecord[]|string $name     The resource record name.
-     * @param string         $type     The type of the resource record.
-     * @param mixed[]|string $content  The content of the resource record. When passing a multidimensional array,
-     *                                 multiple records are created for this resource record.
-     * @param int            $ttl      The TTL.
-     * @param array|mixed[]  $comments The comment to assign to the record.
+     * @param string                                         $type     The type of the resource record.
+     * @param mixed[]|string                                 $content  The content of the resource record. When passing a multidimensional array,
+     *                                                                 multiple records are created for this resource record.
+     * @param int                                            $ttl      The TTL.
+     * @param array|mixed[]                                  $comments The comment to assign to the record.
      *
      * @throws Exceptions\InvalidRecordType If the given type is invalid.
      *
@@ -35,6 +35,7 @@ class Zone extends AbstractZone {
             $resourceRecords = [];
             foreach ($name as $item) {
                 if ($item instanceof ResourceRecord) {
+                    $item->setZone($this)->setName($item->getName());
                     $resourceRecords[] = $item;
                 } else {
                     $resourceRecords[] = $this->make($item['name'], $item['type'], $item['content'], $item['ttl'] ?? $ttl, $item['comments'] ?? []);
@@ -42,6 +43,7 @@ class Zone extends AbstractZone {
             }
         } else {
             if ($name instanceof ResourceRecord) {
+                $name->setZone($this)->setName($name->getName());
                 $resourceRecords = [$name];
             } else {
                 $resourceRecords = [$this->make($name, $type, $content, $ttl, $comments)];

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -176,20 +176,17 @@ class ZoneTest extends TestCase
         $zone = new Zone($connector, 'test.nl');
         $zone->create([
             (new ResourceRecord())
-                ->setZone($zone)
                 ->setName('test')
                 ->setType(RecordType::A)
                 ->setRecord((new Record())
                     ->setContent('127.0.0.1'))
                 ->setTtl(10),
             (new ResourceRecord())
-                ->setZone($zone)
                 ->setName('@')
                 ->setType(RecordType::A)
                 ->setRecord((new Record())->setContent('127.0.0.1'))
                 ->setTtl(20),
             (new ResourceRecord())
-                ->setZone($zone)
                 ->setName('@')
                 ->setType(RecordType::MX)
                 ->setRecords([
@@ -198,14 +195,12 @@ class ZoneTest extends TestCase
                 ])
                 ->setTtl(30),
             (new ResourceRecord())
-                ->setZone($zone)
                 ->setName('test02')
                 ->setType(RecordType::A)
                 ->setRecord((new Record())->setContent('127.0.0.1'))
                 ->setTtl(40),
 
             (new ResourceRecord())
-                ->setZone($zone)
                 ->setName('test03')
                 ->setType(RecordType::TXT)->setRecord((new Record())->setContent('"v=DMARC1; p=none; rua=mailto:info@test.nl; ruf=mailto:info@test.nl"'))
                 ->setTtl(40),

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -3,6 +3,10 @@
 namespace Exonet\Powerdns\tests;
 
 use Exonet\Powerdns\Connector;
+use Exonet\Powerdns\RecordType;
+use Exonet\Powerdns\Resources\Comment;
+use Exonet\Powerdns\Resources\Record;
+use Exonet\Powerdns\Resources\ResourceRecord;
 use Exonet\Powerdns\Resources\Zone as ZoneResource;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
 use Exonet\Powerdns\Zone;
@@ -61,6 +65,34 @@ class ZoneTest extends TestCase
         $zone->create('test', 'A', '127.0.0.1', 10);
     }
 
+    public function testCreateSingleResourceRecordFromClass(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('patch')->withArgs(['zones/test.nl.', Mockery::on(function (RRSetTransformer $transformer) {
+            $data = $transformer->transform();
+
+            $this->assertSame('test.test.nl.', $data->rrsets[0]->name);
+            $this->assertSame('A', $data->rrsets[0]->type);
+            $this->assertSame(10, $data->rrsets[0]->ttl);
+            $this->assertSame('127.0.0.1', $data->rrsets[0]->records[0]->content);
+
+            return true;
+        })]);
+
+        $zone = new Zone($connector, 'test.nl');
+        $rr = (new ResourceRecord())
+            ->setName('test.test.nl.')
+            ->setType(RecordType::A)
+            ->setRecord('127.0.0.1')
+            ->setTtl(10)
+            ->setComments([
+                (new Comment())->setContent('Hello')->setAccount('root')->setModifiedAt(1),
+                (new Comment())->setContent('Power')->setAccount('admin')->setModifiedAt(2),
+                (new Comment())->setContent('DNS')->setAccount('superuser')->setModifiedAt(3),
+            ]);
+        $zone->create($rr);
+    }
+
     public function testCreateMultipleResourceRecords(): void
     {
         $connector = Mockery::mock(Connector::class);
@@ -103,6 +135,80 @@ class ZoneTest extends TestCase
             ['name' => '@', 'type' => 'MX', 'content' => ['10 mail01.test.nl.', '20 mail02.test.nl.'], 'ttl' => 30],
             ['name' => 'test02.test.nl.', 'type' => 'A', 'content' => '127.0.0.1', 'ttl' => 40],
             ['name' => 'test03.test.nl.', 'type' => 'TXT', 'content' => '"v=DMARC1; p=none; rua=mailto:info@test.nl; ruf=mailto:info@test.nl"', 'ttl' => 40],
+        ]);
+    }
+
+    public function testCreateMultipleResourceRecordsFromClass(): void
+    {
+        $connector = Mockery::mock(Connector::class);
+        $connector->shouldReceive('patch')->withArgs(['zones/test.nl.', Mockery::on(function (RRSetTransformer $transformer) {
+            $data = $transformer->transform();
+
+            $this->assertSame('test.test.nl.', $data->rrsets[0]->name);
+            $this->assertSame('A', $data->rrsets[0]->type);
+            $this->assertSame(10, $data->rrsets[0]->ttl);
+            $this->assertSame('127.0.0.1', $data->rrsets[0]->records[0]->content);
+
+            $this->assertSame('test.nl.', $data->rrsets[1]->name);
+            $this->assertSame('A', $data->rrsets[1]->type);
+            $this->assertSame(20, $data->rrsets[1]->ttl);
+            $this->assertSame('127.0.0.1', $data->rrsets[1]->records[0]->content);
+
+            $this->assertSame('test.nl.', $data->rrsets[2]->name);
+            $this->assertSame('MX', $data->rrsets[2]->type);
+            $this->assertSame(30, $data->rrsets[2]->ttl);
+            $this->assertSame('10 mail01.test.nl.', $data->rrsets[2]->records[0]->content);
+            $this->assertSame('20 mail02.test.nl.', $data->rrsets[2]->records[1]->content);
+
+            $this->assertSame('test02.test.nl.', $data->rrsets[3]->name);
+            $this->assertSame('A', $data->rrsets[3]->type);
+            $this->assertSame(40, $data->rrsets[3]->ttl);
+            $this->assertSame('127.0.0.1', $data->rrsets[3]->records[0]->content);
+
+            $this->assertSame('test03.test.nl.', $data->rrsets[4]->name);
+            $this->assertSame('TXT', $data->rrsets[4]->type);
+            $this->assertSame(40, $data->rrsets[4]->ttl);
+            $this->assertSame('"v=DMARC1; p=none; rua=mailto:info@test.nl; ruf=mailto:info@test.nl"', $data->rrsets[4]->records[0]->content);
+
+            return true;
+        })]);
+
+        $zone = new Zone($connector, 'test.nl');
+        $zone->create([
+            (new ResourceRecord())
+                ->setZone($zone)
+                ->setName('test')
+                ->setType(RecordType::A)
+                ->setRecord((new Record())
+                    ->setContent('127.0.0.1'))
+                ->setTtl(10),
+            (new ResourceRecord())
+                ->setZone($zone)
+                ->setName('@')
+                ->setType(RecordType::A)
+                ->setRecord((new Record())->setContent('127.0.0.1'))
+                ->setTtl(20),
+            (new ResourceRecord())
+                ->setZone($zone)
+                ->setName('@')
+                ->setType(RecordType::MX)
+                ->setRecords([
+                    (new Record())->setContent('10 mail01.test.nl.'),
+                    (new Record())->setContent('20 mail02.test.nl.'),
+                ])
+                ->setTtl(30),
+            (new ResourceRecord())
+                ->setZone($zone)
+                ->setName('test02')
+                ->setType(RecordType::A)
+                ->setRecord((new Record())->setContent('127.0.0.1'))
+                ->setTtl(40),
+
+            (new ResourceRecord())
+                ->setZone($zone)
+                ->setName('test03')
+                ->setType(RecordType::TXT)->setRecord((new Record())->setContent('"v=DMARC1; p=none; rua=mailto:info@test.nl; ruf=mailto:info@test.nl"'))
+                ->setTtl(40),
         ]);
     }
 


### PR DESCRIPTION
## Description

As proposed in this discussion: https://github.com/exonet/powerdns-php/discussions/146 here would be an implementation for the mentioned.

## Motivation and context

Keeping track of what parameters to give to the `create` method can get complicated. By enabling the developer to pass Objects we enable a cleaner syntax + enable the usage of auto-complete and other IDE features.

## How has this been tested?

tests are passing, I have tested on 8.1 in my dev-env

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
