### PR TITLE
fix(nsec3): fixes unset nsec3param not working

### DIFF
--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -353,7 +353,7 @@ class Zone
     {
         // If set to null, return,
         if (is_null($nsec3param)) {
-            $this->nsec3param = null;
+            $this->nsec3param = "";
 
             return $this;
         }

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -116,7 +116,7 @@ class ZoneTest extends TestCase
     {
         $zone = new Zone();
         $zone->setNsec3param(null);
-        $this->assertNull($zone->getNsec3param());
+        $this->assertEmpty($zone->getNsec3param());
     }
 
     public function testSetNsec3paramInvalidAlgorithm(): void

--- a/tests/ZoneTest.php
+++ b/tests/ZoneTest.php
@@ -271,7 +271,7 @@ class ZoneTest extends TestCase
         $connector = Mockery::mock(Connector::class);
         $connector->shouldReceive('put')->withArgs(['zones/test.nl.', Mockery::on(function ($transformer) {
             $transformed = $transformer->transform();
-            $this->assertNull($transformed->nsec3param);
+            $this->assertEmpty($transformed->nsec3param);
 
             return true;
         })])->once()->andReturn([]);


### PR DESCRIPTION
## Description

`$powerdns->zone($domain)->unsetNsec3param()`  
  
This wasn't working because `{"nsec3param": null}` was passed in API.  
Now, modified to pass `{"nsec3param": ""}` in API to unset nsec3param.

## How has this been tested?

php: 8.2
powerdns version: 4.9.1-1pdns.buster

All phpunit test cases passed: `./vendor/bin/phpunit`

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
