### PR TITLE
feat: make nameservers auto canoncial

### DIFF
--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -148,12 +148,8 @@ class Powerdns implements PowerdnsInterface
      */
     public function createZone(string $canonicalDomain, array $nameservers, bool $useDnssec = false): Zone
     {
-        $fixDot = substr($canonicalDomain, -1) !== '.';
 
-        if ($fixDot) {
-            $canonicalDomain .= '.';
-        }
-
+        $canonicalDomain = rtrim($canonicalDomain, ".") . ".";
         $newZone = new ZoneResource();
         $newZone->setName($canonicalDomain);
         $newZone->setNameservers($nameservers);

--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -453,7 +453,9 @@ class Zone
      */
     public function setNameservers(array $nameservers): self
     {
-        $this->nameservers = $nameservers;
+        $this->nameservers = array_map(function($ns) {
+            return rtrim($ns, '.') . '.';
+        }, $nameservers);
 
         return $this;
     }

--- a/tests/Resources/ZoneTest.php
+++ b/tests/Resources/ZoneTest.php
@@ -65,11 +65,10 @@ class ZoneTest extends TestCase
         $this->assertNull($zone->getAccount());
     }
 
-    public function testSetNameservers(): void
-    {
+    public function testSetNameserversCanoncial(): void {
         $zone = new Zone();
-        $zone->setNameservers(['foo', 'bar']);
-        $this->assertSame(['foo', 'bar'], $zone->getNameservers());
+        $zone->setNameservers(['ns1', 'ns2']);
+        $this->assertSame(['ns1.', 'ns2.'], $zone->getNameservers());
     }
 
     public function testSetKind(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

the `#setNameservers` method will accept any input, while powerdns only accept canonical nameservers (ending in `.`). With the PR, the dot will be automatically appended if it's missing.

## Motivation and context

Automatically settings this resolve an issue i'm having with customer not setting the appending dot.

## How has this been tested?

tests were fitted

## Checklist:

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
