### PR TITLE
add api_rectify handling for zones

### DIFF
--- a/src/Transformers/ApiRectifyTransformer.php
+++ b/src/Transformers/ApiRectifyTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Exonet\Powerdns\Transformers;
+
+class ApiRectifyTransformer extends Transformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform()
+    {
+        return (object) [
+            'api_rectify' => $this->data['api_rectify'],
+        ];
+    }
+}

--- a/src/Zone.php
+++ b/src/Zone.php
@@ -11,6 +11,7 @@ use Exonet\Powerdns\Transformers\Nsec3paramTransformer;
 use Exonet\Powerdns\Transformers\RRSetTransformer;
 use Exonet\Powerdns\Transformers\SoaEditApiTransformer;
 use Exonet\Powerdns\Transformers\SoaEditTransformer;
+use Exonet\Powerdns\Transformers\ApiRectifyTransformer;
 use Exonet\Powerdns\Transformers\Transformer;
 
 class Zone extends AbstractZone
@@ -299,6 +300,41 @@ class Zone extends AbstractZone
         return $this->put(new SoaEditApiTransformer(['soa_edit_api' => $value]));
     }
 
+    /**
+     * Enable api_rectify for this zone.
+     *
+     * @return bool True when enabled.
+     */
+    public function enableApiRectify(): bool
+    {
+        return $this->setApiRectify(true);
+    }
+
+    /**
+     * Disable  api_rectify for this zone.
+     *
+     * @return bool True when disabled.
+     */
+    public function disableApiRectify(): bool
+    {
+        return $this->setApiRectify(false);
+    }
+
+    /**
+     * Enable or disable api_rectify for this zone.
+     *
+     * @param bool $state True to enable, false to disable.
+     *
+     * @return bool True when the request succeeded.
+     */
+    public function setApiRectify(bool $state): bool
+    {
+        return $this->put(new ApiRectifyTransformer(['api_rectify' => $state]));
+    }
+
+    /**
+
+    
     /**
      * Set the kind of zone: Native, Master or Slave.
      *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

basically added enableApiRectify() and disableApiRectify() in order to be able to set this parameter for a zone.

## Motivation and context

While api_rectify is present as a readonly value for the zones, there is no method to set this parameter.

## How has this been tested?

called $powerdns->zone($domain)->enableApiRectify();
and $powerdns->zone($domain)->disableApiRectify();

verified changes on powerdns-server - as it is quite trivial - this got it approved internally.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] My pull request contains a title that can be used as a release note.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. (couldn't find an option to add the tests - also missing for soa_edit_api)
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
