### PR TITLE
Define git archive excluded files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+.docker/               export-ignore
+.github/               export-ignore
+examples/              export-ignore
+tests/                 export-ignore
+.editorconfig          export-ignore
+.gitattributes         export-ignore
+.gitignore             export-ignore
+.php-cs-fixer.php      export-ignore
+docker-compose.yml     export-ignore
+phpunit.xml            export-ignore
+run-tests.sh           export-ignore

--- a/examples/cryptokeys_advanced.php
+++ b/examples/cryptokeys_advanced.php
@@ -25,16 +25,16 @@ $cryptokeys = $powerdns->cryptokeys($domain);
 $cryptokeys->configurePrivateKey('RSASHA512', 4096)->create(true);
 
 // You can also use an existing private key (example key from the PowerDNS unit tests):
-$existingPrivateKey = "Private-key-format: v1.2\n".
-    "Algorithm: 8 (RSASHA256)\n".
-    "Modulus: 4GlYLGgDI7ohnP8SmEW8EBERbNRusDcg0VQda/EPVHU=\n".
-    "PublicExponent: AQAB\n".
-    "PrivateExponent: JBnuXF5zOtkjtSz3odV+Fk5UNUTTeCsiI16dkcM7TVU=\n".
-    "Prime1: /w7TM4118RoSEvP8+dgnCw==\n".
-    "Prime2: 4T2KhkYLa3w7rdK3Cb2ifw==\n".
-    "Exponent1: 3aeKj9Ct4JuhfWsgPBhGxQ==\n".
-    "Exponent2: tfh1OMPQKBdnU6iATjNR2w==\n".
-    "Coefficient: eVrHe/kauqOewSKndIImrg==)\n";
+$existingPrivateKey = "Private-key-format: v1.2\n"
+    ."Algorithm: 8 (RSASHA256)\n"
+    ."Modulus: 4GlYLGgDI7ohnP8SmEW8EBERbNRusDcg0VQda/EPVHU=\n"
+    ."PublicExponent: AQAB\n"
+    ."PrivateExponent: JBnuXF5zOtkjtSz3odV+Fk5UNUTTeCsiI16dkcM7TVU=\n"
+    ."Prime1: /w7TM4118RoSEvP8+dgnCw==\n"
+    ."Prime2: 4T2KhkYLa3w7rdK3Cb2ifw==\n"
+    ."Exponent1: 3aeKj9Ct4JuhfWsgPBhGxQ==\n"
+    ."Exponent2: tfh1OMPQKBdnU6iATjNR2w==\n"
+    ."Coefficient: eVrHe/kauqOewSKndIImrg==)\n";
 
 // Create and activate a new cryptokey with the given private key:
 $cryptokeys->setPrivateKey($existingPrivateKey)->create(true);

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -93,11 +93,6 @@ class PowerdnsTest extends TestCase
         $this->assertTrue($powerDns->deleteZone('test.nl.'));
     }
 
-    public function listZonesArgumentDataProvider(): array
-    {
-        return [['true', true], ['false', false]];
-    }
-
     /**
      * @dataProvider listZonesArgumentDataProvider
      */
@@ -141,6 +136,11 @@ class PowerdnsTest extends TestCase
         foreach ($response as $zone) {
             $this->assertInstanceOf(Zone::class, $zone);
         }
+    }
+
+    public function listZonesArgumentDataProvider(): array
+    {
+        return [['true', true], ['false', false]];
     }
 
     public function testSearch(): void

--- a/tests/Resources/ResourceRecordTest.php
+++ b/tests/Resources/ResourceRecordTest.php
@@ -51,8 +51,8 @@ class ResourceRecordTest extends TestCase
 
     public function testSetApiResponse(): void
     {
-        $apiResponse =
-            [
+        $apiResponse
+            = [
                 'name' => 'record.test.nl.',
                 'type' => 'A',
                 'ttl' => 3600,


### PR DESCRIPTION
## Description
Add a `.gitattributes` file that defines which files to exclude in when running `git archive`.

When composer-installing this package now only the following files are downloaded:
- src/
- composer.json
- LICENSE.md
- README.md

More info on export-ignore via gitattributes: https://git-scm.com/docs/gitattributes#_export_ignore

## Motivation and context
This reduces the size of the package when installing via composer. Files that are not needed to run the package in another project are no longer included. For example the tests.

## How has this been tested?

Run `git archive -o latest.zip HEAD` and see the zip archive no longer contains things like tests.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [X] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] My pull request contains a title that can be used as a release note.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- ~I have added tests to cover my changes.~
- [X] If my change requires a change to the documentation, I have updated it accordingly.