### PR TITLE
Remove not-working iterations check

### DIFF
--- a/src/Resources/Zone.php
+++ b/src/Resources/Zone.php
@@ -367,7 +367,7 @@ class Zone
         if ($flags === null || !ctype_digit($flags) || ((int) $flags !== 0 && (int) $flags !== 1)) {
             throw new InvalidNsec3Param('The nsec3param flags parameter must be set to 0 or 1.');
         }
-        if ($iterations === null || !ctype_digit($iterations) || $iterations === 0 || $iterations > 2500) {
+        if ($iterations === null || !ctype_digit($iterations) || $iterations > 2500) {
             throw new InvalidNsec3Param('The nsec3param iterations parameter must be between 0 and 2500.');
         }
         if ($salt === null || strlen($salt) === 0 || strlen($salt) > 255) {


### PR DESCRIPTION
## Description
Remove not-working iterations check. Iteration 0 is valid. This check was not working due to strict-compare between string and int always returning false

Even when providing 0 as iteration it was comparing `'0' === 0`. Because this is a strict-compare, it always returns false.

## Motivation and context
It removes code that looks like it should prevent using 0 as iteration while in reality this was not the case. 

## How has this been tested?
All tests ran and pass. Some testcases use 0 as iteration and they still are passing.
