### PR TITLE
Fix deprecation warning that occurs in PHP 8.5

### DIFF
--- a/src/Resources/ResourceRecord.php
+++ b/src/Resources/ResourceRecord.php
@@ -384,7 +384,7 @@ class ResourceRecord
             throw new InvalidRecordType('Changing the type of existing DNS resource records can yield unexpected results and is not supported.');
         }
 
-        if ((new ReflectionClass(RecordType::class))->getConstant($type) !== false) {
+        if ((new ReflectionClass(RecordType::class))->hasConstant($type) !== false) {
             $this->type = $type;
 
             return $this;


### PR DESCRIPTION
getConstant will no longer return false in future php versions and now raises a warning in php 8.5 when checked against the value being false.

## Description

Changes the usage of getConstant to hasConstant

https://www.php.net/manual/en/reflectionclass.getconstant.php

https://www.php.net/manual/en/reflectionclass.hasconstant.php

hasConstant has been supported since PHP 5.1.2, so there shouldn't be an issue support wise.

## Motivation and context

Removes depreciation warning in PHP 8.5

## How has this been tested?

Used the included run-tests script and updated it to include PHP 8.5.

## Checklist:

- [x] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
