### PR TITLE
feat: add support for optional subdirectory in PowerDNS API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ use Exonet\Powerdns\Resources\Record;
 // Initialize the Powerdns client.
 $powerdns = new Powerdns('127.0.0.1', 'powerdns_secret_string');
 
+// Optional: when PowerDNS is served behind a subdirectory (for example /dnsadmin).
+$powerdnsBehindSubdirectory = new Powerdns(
+    'example.com',
+    'powerdns_secret_string',
+    443,
+    'localhost',
+    null,
+    'dnsadmin'
+);
+
 // Create a new zone.
 $zone = $powerdns->createZone(
     'example.com',

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -178,12 +178,15 @@ class Connector implements ConnectorInterface
     protected function buildUrl(string $path): string
     {
         $config = $this->powerdns->getConfig();
+        $subDirectory = trim($config['subDirectory'] ?? '', '/');
+        $apiPathPrefix = $subDirectory === '' ? '/api/v1' : '/'.$subDirectory.'/api/v1';
 
         return rtrim(
             sprintf(
-                '%s:%d/api/v1/servers/%s/%s',
-                $config['host'],
+                '%s:%d%s/servers/%s/%s',
+                rtrim($config['host'], '/'),
                 $config['port'],
+                $apiPathPrefix,
                 $config['server'],
                 $path
             ),

--- a/src/Powerdns.php
+++ b/src/Powerdns.php
@@ -48,6 +48,11 @@ class Powerdns implements PowerdnsInterface
     private $server = 'localhost';
 
     /**
+     * @var string The optional subdirectory in front of the API path.
+     */
+    private $subDirectory = '';
+
+    /**
      * @var ConnectorInterface The PowerDNS Connector to make calls.
      */
     private $connector;
@@ -55,18 +60,20 @@ class Powerdns implements PowerdnsInterface
     /**
      * PowerDNS Client constructor.
      *
-     * @param string|null             $host      (optional) The PowerDNS host. Must include protocol (http, https, etc.).
-     * @param string|null             $apiKey    (optional) The PowerDNS API key.
-     * @param int|null                $port      (optional) The PowerDNS API Port.
-     * @param string|null             $server    (optional) The PowerDNS server to use.
-     * @param ConnectorInterface|null $connector (optional) The Connector to make calls.
+     * @param string|null             $host         (optional) The PowerDNS host. Must include protocol (http, https, etc.).
+     * @param string|null             $apiKey       (optional) The PowerDNS API key.
+     * @param int|null                $port         (optional) The PowerDNS API Port.
+     * @param string|null             $server       (optional) The PowerDNS server to use.
+     * @param ConnectorInterface|null $connector    (optional) The Connector to make calls.
+     * @param string|null             $subDirectory (optional) Subdirectory in front of the API path.
      */
     public function __construct(
         ?string $host = null,
         ?string $apiKey = null,
         ?int $port = null,
         ?string $server = null,
-        ?ConnectorInterface $connector = null
+        ?ConnectorInterface $connector = null,
+        ?string $subDirectory = null
     ) {
         if (self::$_instance === null) {
             self::$_instance = $this;
@@ -86,6 +93,10 @@ class Powerdns implements PowerdnsInterface
 
         if ($server !== null) {
             $this->server = $server;
+        }
+
+        if ($subDirectory !== null) {
+            $this->subDirectory = trim($subDirectory, '/');
         }
 
         $this->connector = $connector ?? new Connector($this);
@@ -108,17 +119,23 @@ class Powerdns implements PowerdnsInterface
     /**
      * Configure a new connection to a PowerDNS server.
      *
-     * @param string $host   The PowerDNS host. Must include protocol (http, https, etc.).
-     * @param int    $port   The PowerDNS API Port.
-     * @param string $server The PowerDNS server to use.
+     * @param string $host         The PowerDNS host. Must include protocol (http, https, etc.).
+     * @param int    $port         The PowerDNS API Port.
+     * @param string $server       The PowerDNS server to use.
+     * @param string $subDirectory (optional) Subdirectory in front of the API path.
      *
      * @return PowerdnsInterface The created PowerDNS client.
      */
-    public function connect(string $host, int $port = 8081, string $server = 'localhost'): PowerdnsInterface
-    {
+    public function connect(
+        string $host,
+        int $port = 8081,
+        string $server = 'localhost',
+        string $subDirectory = ''
+    ): PowerdnsInterface {
         $this->host = $host;
         $this->port = $port;
         $this->server = $server;
+        $this->subDirectory = trim($subDirectory, '/');
 
         return $this;
     }
@@ -355,6 +372,7 @@ class Powerdns implements PowerdnsInterface
             'port' => $this->port,
             'server' => $this->server,
             'apiKey' => $this->apiKey,
+            'subDirectory' => $this->subDirectory,
         ];
     }
 }

--- a/src/PowerdnsInterface.php
+++ b/src/PowerdnsInterface.php
@@ -13,13 +13,19 @@ interface PowerdnsInterface
     /**
      * Configure a new connection to a PowerDNS server.
      *
-     * @param string $host   The PowerDNS host. Must include protocol (http, https, etc.).
-     * @param int    $port   The PowerDNS API Port.
-     * @param string $server The PowerDNS server to use.
+     * @param string $host         The PowerDNS host. Must include protocol (http, https, etc.).
+     * @param int    $port         The PowerDNS API Port.
+     * @param string $server       The PowerDNS server to use.
+     * @param string $subDirectory (optional) Subdirectory in front of the API path.
      *
      * @return Powerdns The created PowerDNS client.
      */
-    public function connect(string $host, int $port = 8081, string $server = 'localhost'): self;
+    public function connect(
+        string $host,
+        int $port = 8081,
+        string $server = 'localhost',
+        string $subDirectory = ''
+    ): self;
 
     /**
      * Set the authorization key to use for each request.

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -93,4 +93,37 @@ class ConnectorTest extends TestCase
             $this->assertSame('exonet-powerdns-php/'.Powerdns::CLIENT_VERSION, $request->getHeader('User-Agent')[0]);
         }
     }
+
+    public function testApiCallsSupportSubdirectoryPath()
+    {
+        $apiCalls = [];
+        $mock = new MockHandler(
+            [
+                new Response(200, [], json_encode(['server_response' => 'hello world'])),
+            ]
+        );
+
+        $history = Middleware::history($apiCalls);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+
+        $powerDnsClient = Mockery::mock(Powerdns::class);
+        $powerDnsClient->shouldReceive('log')->andReturn(new NullLogger());
+        $powerDnsClient->shouldReceive('getConfig')->withNoArgs()->andReturn(
+            [
+                'host' => 'https://admin.cs.fhwn.ac.at',
+                'port' => 443,
+                'server' => 'localhost',
+                'apiKey' => 'very_secret_key',
+                'subDirectory' => 'dnsadmin',
+            ]
+        );
+
+        $connectorClass = new Connector($powerDnsClient, $handler);
+        $connectorClass->get('test');
+
+        /** @var Request $request */
+        $request = $apiCalls[0]['request'];
+        $this->assertSame('/dnsadmin/api/v1/servers/localhost/test', $request->getUri()->getPath());
+    }
 }

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -111,8 +111,8 @@ class ConnectorTest extends TestCase
         $powerDnsClient->shouldReceive('log')->andReturn(new NullLogger());
         $powerDnsClient->shouldReceive('getConfig')->withNoArgs()->andReturn(
             [
-                'host' => 'https://admin.cs.fhwn.ac.at',
-                'port' => 443,
+                'host' => 'http://test',
+                'port' => 1234,
                 'server' => 'localhost',
                 'apiKey' => 'very_secret_key',
                 'subDirectory' => 'dnsadmin',

--- a/tests/PowerdnsTest.php
+++ b/tests/PowerdnsTest.php
@@ -17,13 +17,14 @@ class PowerdnsTest extends TestCase
 {
     public function testConfigViaConstructor(): void
     {
-        $powerDns = new Powerdns('test-host', 'test-key', 1234, 'test-server');
+        $powerDns = new Powerdns('test-host', 'test-key', 1234, 'test-server', null, 'dnsadmin');
         $config = $powerDns->getConfig();
 
         $this->assertSame('test-host', $config['host']);
         $this->assertSame(1234, $config['port']);
         $this->assertSame('test-server', $config['server']);
         $this->assertSame('test-key', $config['apiKey']);
+        $this->assertSame('dnsadmin', $config['subDirectory']);
     }
 
     public function testConfigViaMethods(): void
@@ -37,6 +38,21 @@ class PowerdnsTest extends TestCase
         $this->assertSame(1234, $config['port']);
         $this->assertSame('test-server', $config['server']);
         $this->assertSame('test-key', $config['apiKey']);
+        $this->assertSame('', $config['subDirectory']);
+    }
+
+    public function testConfigViaMethodsWithSubdirectory(): void
+    {
+        $powerDns = new Powerdns();
+        $powerDns->connect('test-host', 1234, 'test-server', '/dnsadmin/');
+        $powerDns->useKey('test-key');
+        $config = $powerDns->getConfig();
+
+        $this->assertSame('test-host', $config['host']);
+        $this->assertSame(1234, $config['port']);
+        $this->assertSame('test-server', $config['server']);
+        $this->assertSame('test-key', $config['apiKey']);
+        $this->assertSame('dnsadmin', $config['subDirectory']);
     }
 
     public function testStatistics(): void


### PR DESCRIPTION
## Description

Currently powerdns-php does not support powerdns-admin to be hosted in a subdirectory

## Motivation and context

I host my powerdns-admin in a subdirectory rather then their own hostname. The API currently can't handle this. I have added the subDirectory option to specify this in the connection URL.

## How has this been tested?

I used the provided tests and also used the updated library on my own setup.

## Screenshots (if appropriate)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests pass](https://help.github.com/articles/about-required-status-checks/).

- [x ] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [ x] My pull request addresses exactly one patch/feature.
- [ x] My pull request contains a title that can be used as a release note.
- [ x] I have created a branch for this patch/feature.
- [ x] Each individual commit in the pull request is meaningful.
- [ x] I have added tests to cover my changes.
- [ x] If my change requires a change to the documentation, I have updated it accordingly.

